### PR TITLE
Only make search bar visible if enabled, fixes #74

### DIFF
--- a/app/src/main/java/com/benny/openlauncher/activity/Home.java
+++ b/app/src/main/java/com/benny/openlauncher/activity/Home.java
@@ -333,7 +333,8 @@ public class Home extends Activity implements DrawerLayout.DrawerListener, Deskt
 
             @Override
             public void onCollapse() {
-                Tool.visibleViews(desktopIndicator, searchBarClock, desktopDock, desktop);
+                Tool.visibleViews(desktopIndicator, desktop);
+                updateSearchBarVisibility();
                 Tool.invisibleViews(background);
 
                 searchBar.searchBox.clearFocus();
@@ -459,7 +460,8 @@ public class Home extends Activity implements DrawerLayout.DrawerListener, Deskt
     public void onFinishDesktopEdit() {
         dragOptionPanel.setAutoHideView(searchClock, searchBar);
 
-        Tool.visibleViews(100, desktopIndicator, searchClock, searchBar, desktopDock);
+        Tool.visibleViews(100, desktopIndicator, desktopDock);
+        updateSearchBarVisibility();
         Tool.invisibleViews(100, desktopEditOptionPanel);
     }
 
@@ -526,11 +528,7 @@ public class Home extends Activity implements DrawerLayout.DrawerListener, Deskt
     }
 
     private void initSettings() {
-        if (generalSettings.desktopSearchBar) {
-            searchClock.setVisibility(View.VISIBLE);
-        } else {
-            searchClock.setVisibility(View.GONE);
-        }
+        updateSearchBarVisibility();
 
         if (generalSettings.fullscreen) {
             getWindow().setFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN, WindowManager.LayoutParams.FLAG_FULLSCREEN);


### PR DESCRIPTION
Always use updateSearchBarVisibility() to set search bar visibility as that checks the enable setting. This is intended as the quick fix solution, it would probably be better long term for the clock to be part of the ASearchBar class so Home doesn't deal with the internals of what appears to the user as a single widget, it just enables or disables it.