### PR TITLE
Allow for widget size when converting touch coords to cell position, fixes #62

### DIFF
--- a/app/src/main/java/com/benny/openlauncher/widget/CellContainer.java
+++ b/app/src/main/java/com/benny/openlauncher/widget/CellContainer.java
@@ -441,7 +441,20 @@ public class CellContainer extends ViewGroup {
         return null;
     }
 
+    /**
+     * Convert a position in screen coordinates for the centre of an object to a Point in cell
+     * coordinates representing the top left cell that the object must occupy for the centre to
+     * be as close as possible to the supplied position
+     * @param mX - X position of centre in screen coordinates
+     * @param mY - Y position of centre in screen coordinates
+     * @param xSpan - The width of the object in cells, must be >= 1
+     * @param ySpan - The height of the object in cells, must be >= 1
+     * @param checkAvailability - this parameter probably doesn't make any difference any more
+     * @return - a point representing the ideal x,y position or null
+     */
     public Point touchPosToCoordinate(int mX, int mY, int xSpan, int ySpan, boolean checkAvailability) {
+        mX = mX - (xSpan-1)*cellWidth/2;
+        mY = mY - (ySpan-1)*cellHeight/2;
         for (int x = 0; x < cellSpanH; x++) {
             for (int y = 0; y < cellSpanV; y++) {
                 Rect cell = cells[x][y];

--- a/app/src/main/java/com/benny/openlauncher/widget/Desktop.java
+++ b/app/src/main/java/com/benny/openlauncher/widget/Desktop.java
@@ -284,6 +284,13 @@ public class Desktop extends SmoothViewPager implements OnDragListener, DesktopC
         }
     }
 
+    /**
+     * Add an item to the specified position on the current page
+     * @param item - the item to add
+     * @param x - x position in screen coordinates of the centre of the item
+     * @param y - y position in screen coordinates of the centre of the item
+     * @return - true if the item was added, false if not enough space
+     */
     @Override
     public boolean addItemToPoint(final Item item, int x, int y) {
         CellContainer.LayoutParams positionToLayoutPrams = getCurrentPage().positionToLayoutPrams(x, y, item.spanX, item.spanY);


### PR DESCRIPTION
I've added JavaDoc style documentation to the methods that I had to understand in order to fix this issue. I figured once I'd put the effort into working out what the code did I might as well write it down to help the next person who looks at it.