### PR TITLE
Correct space calculation in coordinateToChildView()

### DIFF
--- a/app/src/main/java/com/benny/openlauncher/widget/CellContainer.java
+++ b/app/src/main/java/com/benny/openlauncher/widget/CellContainer.java
@@ -432,7 +432,7 @@ public class CellContainer extends ViewGroup {
         if (pos == null) return null;
         for (int i = 0; i < getChildCount(); i++) {
             LayoutParams lp = (LayoutParams) getChildAt(i).getLayoutParams();
-            if (pos.x >= lp.x && pos.y >= lp.y && pos.x <= lp.x + lp.xSpan && pos.y <= lp.y + lp.ySpan) {
+            if (pos.x >= lp.x && pos.y >= lp.y && pos.x < lp.x + lp.xSpan && pos.y < lp.y + lp.ySpan) {
                 return getChildAt(i);
             }
         }


### PR DESCRIPTION
This was treating objects as 1 cell below and to the right larger than they actually were resulting in difficulty creating groups as the wrong Item was being identified to form the group.