### PR TITLE
Fallback on a browser if no search app is installed

### DIFF
--- a/app/src/main/java/com/benny/openlauncher/activity/Home.java
+++ b/app/src/main/java/com/benny/openlauncher/activity/Home.java
@@ -501,13 +501,13 @@ public class Home extends Activity implements DrawerLayout.DrawerListener, Deskt
         searchBar.setCallback(new SearchBar.CallBack() {
             @Override
             public void onInternetSearch(String string) {
-                Intent intent = null;
+                Intent intent = new Intent();
 
                 if (Tool.isIntentAvailable(getApplicationContext(), Intent.ACTION_WEB_SEARCH)) {
-                    intent = new Intent(Intent.ACTION_WEB_SEARCH);
+                    intent.setAction(Intent.ACTION_WEB_SEARCH);
                     intent.putExtra(SearchManager.QUERY, string);
                 } else {
-                    intent = new Intent(Intent.ACTION_VIEW);
+                    intent.setAction(Intent.ACTION_VIEW);
                     intent.setData(Uri.parse(appSettings.getSearchBarBaseURI()+string));
                 }
 

--- a/app/src/main/java/com/benny/openlauncher/activity/Home.java
+++ b/app/src/main/java/com/benny/openlauncher/activity/Home.java
@@ -501,8 +501,16 @@ public class Home extends Activity implements DrawerLayout.DrawerListener, Deskt
         searchBar.setCallback(new SearchBar.CallBack() {
             @Override
             public void onInternetSearch(String string) {
-                Intent intent = new Intent(Intent.ACTION_WEB_SEARCH);
-                intent.putExtra(SearchManager.QUERY, string);
+                Intent intent = null;
+
+                if (Tool.isIntentAvailable(getApplicationContext(), Intent.ACTION_WEB_SEARCH)) {
+                    intent = new Intent(Intent.ACTION_WEB_SEARCH);
+                    intent.putExtra(SearchManager.QUERY, string);
+                } else {
+                    intent = new Intent(Intent.ACTION_VIEW);
+                    intent.setData(Uri.parse(appSettings.getSearchBarBaseURI()+string));
+                }
+
                 try {
                     startActivity(intent);
                 } catch (Exception e) {

--- a/app/src/main/java/com/benny/openlauncher/activity/Home.java
+++ b/app/src/main/java/com/benny/openlauncher/activity/Home.java
@@ -507,8 +507,11 @@ public class Home extends Activity implements DrawerLayout.DrawerListener, Deskt
                     intent.setAction(Intent.ACTION_WEB_SEARCH);
                     intent.putExtra(SearchManager.QUERY, string);
                 } else {
+                    String baseUri = appSettings.getSearchBarBaseURI();
+                    String searchUri = baseUri.contains("{query}") ? baseUri.replace("{query}", string) : (baseUri + string);
+
                     intent.setAction(Intent.ACTION_VIEW);
-                    intent.setData(Uri.parse(appSettings.getSearchBarBaseURI()+string));
+                    intent.setData(Uri.parse(searchUri));
                 }
 
                 try {

--- a/app/src/main/java/com/benny/openlauncher/util/AppSettings.java
+++ b/app/src/main/java/com/benny/openlauncher/util/AppSettings.java
@@ -59,6 +59,10 @@ public class AppSettings extends AppSettingsBase {
         return getBool(R.string.pref_key__desktop_show_label, true);
     }
 
+    public String getSearchBarBaseURI() {
+        return getString(R.string.pref_key__search_bar_base_uri, R.string.pref_default__search_bar_base_uri);
+    }
+
     public int getDesktopColor() {
         return getInt(R.string.pref_key__desktop_background_color, Color.TRANSPARENT);
     }

--- a/app/src/main/java/com/benny/openlauncher/util/Tool.java
+++ b/app/src/main/java/com/benny/openlauncher/util/Tool.java
@@ -45,6 +45,7 @@ import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
+import java.util.List;
 import java.util.Random;
 
 import static android.content.Context.ACTIVITY_SERVICE;
@@ -613,6 +614,17 @@ public class Tool {
 
         } catch (Exception e) {
             Toast.makeText(context, R.string.dialog__backup_app_settings__error, Toast.LENGTH_SHORT).show();
+        }
+    }
+
+    public static boolean isIntentAvailable(Context context, String action) {
+        final PackageManager packageManager = context.getPackageManager();
+        final Intent intent = new Intent(action);
+        List resolveInfo = packageManager.queryIntentActivities(intent, PackageManager.MATCH_DEFAULT_ONLY);
+        if (resolveInfo.size() > 0) {
+            return true;
+        } else {
+            return false;
         }
     }
 }

--- a/app/src/main/java/com/benny/openlauncher/util/Tool.java
+++ b/app/src/main/java/com/benny/openlauncher/util/Tool.java
@@ -621,10 +621,6 @@ public class Tool {
         final PackageManager packageManager = context.getPackageManager();
         final Intent intent = new Intent(action);
         List resolveInfo = packageManager.queryIntentActivities(intent, PackageManager.MATCH_DEFAULT_ONLY);
-        if (resolveInfo.size() > 0) {
-            return true;
-        } else {
-            return false;
-        }
+        return resolveInfo.size() > 0;
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -93,8 +93,10 @@
     <string name="pref_title__desktop_show_label">Show Labels</string>
     <string name="pref_summary__desktop_show_label">Show item labels below their icons.</string>
     <string name="pref_title__search_bar_base_uri">Search URI</string>
-    <string name="pref_summary__search_bar_base_uri">Base URI for web searches (the search term will be appended at the end).</string>
-    <string name="pref_default__search_bar_base_uri" translatable="false">https://google.com/search?q=</string>
+    <string name="pref_summary__search_bar_base_uri">Set the URI used for web searches.</string>
+    <string name="pref_dialog__search_bar_base_uri">Enter the URI that should be used for web searches. The tag {query} can be used as
+      placeholder for the search query, in case no placeholder is used the search query will be appended at the end of the URI.</string>
+    <string name="pref_default__search_bar_base_uri" translatable="false">https://google.com/search?q={query}</string>
     <string name="pref_title__desktop_background_color">Background</string>
     <string name="pref_title__desktop_folder_color">Folder</string>
     <string name="pref_title__minibar_background_color" translatable="false">@string/minibar</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -78,6 +78,7 @@
     <string name="pref_title__size">Size</string>
     <string name="pref_title__appearance">Appearance</string>
     <string name="pref_title__color">Colors</string>
+    <string name="pref_title__search_bar">Search Bar</string>
 
     <string name="pref_title__desktop_style">Style</string>
     <string name="pref_summary__desktop_style">Choose between a normal desktop and showing all installed apps.</string>
@@ -91,6 +92,9 @@
     <string name="pref_summary__desktop_show_position_indicator">Show the page indicator below the desktop.</string>
     <string name="pref_title__desktop_show_label">Show Labels</string>
     <string name="pref_summary__desktop_show_label">Show item labels below their icons.</string>
+    <string name="pref_title__search_bar_base_uri">Search URI</string>
+    <string name="pref_summary__search_bar_base_uri">Base URI for web searches (the search term will be appended at the end).</string>
+    <string name="pref_default__search_bar_base_uri" translatable="false">https://google.com/search?q=</string>
     <string name="pref_title__desktop_background_color">Background</string>
     <string name="pref_title__desktop_folder_color">Folder</string>
     <string name="pref_title__minibar_background_color" translatable="false">@string/minibar</string>
@@ -155,6 +159,7 @@
     <string name="pref_key__desktop_fullscreen" translatable="false">pref_key__desktop_fullscreen</string>
     <string name="pref_key__desktop_show_position_indicator" translatable="false">pref_key__desktop_show_position_indicator</string>
     <string name="pref_key__desktop_show_label" translatable="false">pref_key__desktop_show_label</string>
+    <string name="pref_key__search_bar_base_uri" translatable="false">pref_key__search_bar_base_uri</string>
     <string name="pref_key__desktop_background_color" translatable="false">pref_key__desktop_background_color</string>
     <string name="pref_key__desktop_folder_color" translatable="false">pref_key__desktop_folder_color</string>
     <string name="pref_key__minibar_background_color" translatable="false">pref_key__minibar_background_color</string>

--- a/app/src/main/res/xml/preferences_desktop.xml
+++ b/app/src/main/res/xml/preferences_desktop.xml
@@ -59,6 +59,17 @@
 
     </PreferenceCategory>
 
+    <PreferenceCategory android:title="@string/pref_title__search_bar">
+
+        <EditTextPreference
+            android:defaultValue="@string/pref_default__search_bar_base_uri"
+            android:key="@string/pref_key__search_bar_base_uri"
+            android:summary="@string/pref_summary__search_bar_base_uri"
+            android:title="@string/pref_title__search_bar_base_uri"
+            android:inputType="textUri" />
+
+    </PreferenceCategory>
+
     <PreferenceCategory android:title="@string/pref_title__color">
 
         <com.jaredrummler.android.colorpicker.ColorPreference

--- a/app/src/main/res/xml/preferences_desktop.xml
+++ b/app/src/main/res/xml/preferences_desktop.xml
@@ -66,6 +66,7 @@
             android:key="@string/pref_key__search_bar_base_uri"
             android:summary="@string/pref_summary__search_bar_base_uri"
             android:title="@string/pref_title__search_bar_base_uri"
+            android:hint="@string/pref_default__search_bar_base_uri"
             android:inputType="textUri" />
 
     </PreferenceCategory>

--- a/app/src/main/res/xml/preferences_desktop.xml
+++ b/app/src/main/res/xml/preferences_desktop.xml
@@ -66,6 +66,7 @@
             android:key="@string/pref_key__search_bar_base_uri"
             android:summary="@string/pref_summary__search_bar_base_uri"
             android:title="@string/pref_title__search_bar_base_uri"
+            android:dialogMessage="@string/pref_dialog__search_bar_base_uri"
             android:hint="@string/pref_default__search_bar_base_uri"
             android:inputType="textUri" />
 


### PR DESCRIPTION
This is my implementation of a fallback online search using the ACTION_VIEW intent in case no search app is installed.
The URI used for this search can be configured in the settings, by default Google is used.

Fixes  #158 