### PR TITLE
Add the option to always use the browser for online search

### DIFF
--- a/app/src/main/java/com/benny/openlauncher/util/AppSettings.java
+++ b/app/src/main/java/com/benny/openlauncher/util/AppSettings.java
@@ -62,6 +62,10 @@ public class AppSettings extends AppSettingsBase implements SettingsManager {
         return getString(R.string.pref_key__search_bar_base_uri, R.string.pref_default__search_bar_base_uri);
     }
 
+    public boolean getSearchBarForceBrowser() {
+        return getBool(R.string.pref_key__search_bar_force_browser, false);
+    }
+
     @Override
     public boolean isSearchBarTimeEnabled() {
         return true;

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -83,6 +83,8 @@
     <string name="pref_summary__desktop_show_label">Show item labels below their icons.</string>
     <string name="pref_title__search_bar_base_uri">Search URI</string>
     <string name="pref_summary__search_bar_base_uri">Set the URI used for web searches.</string>
+    <string name="pref_title__search_bar_force_browser">Force browser search</string>
+    <string name="pref_summary__search_bar_force_browser">Always use the browser for online searches.</string>
     <string name="pref_dialog__search_bar_base_uri">Enter the URI that should be used for web searches. The tag {query} can be used as
       placeholder for the search query, in case no placeholder is used the search query will be appended at the end of the URI.</string>
     <string name="pref_title__desktop_background_color">Background</string>
@@ -151,6 +153,7 @@
     <string name="pref_key__desktop_show_position_indicator" translatable="false">pref_key__desktop_show_position_indicator</string>
     <string name="pref_key__desktop_show_label" translatable="false">pref_key__desktop_show_label</string>
     <string name="pref_key__search_bar_base_uri" translatable="false">pref_key__search_bar_base_uri</string>
+    <string name="pref_key__search_bar_force_browser" translatable="false">pref_key__search_bar_force_browser</string>
     <string name="pref_key__desktop_background_color" translatable="false">pref_key__desktop_background_color</string>
     <string name="pref_key__desktop_folder_color" translatable="false">pref_key__desktop_folder_color</string>
     <string name="pref_key__minibar_background_color" translatable="false">pref_key__minibar_background_color</string>

--- a/app/src/main/res/xml/preferences_desktop.xml
+++ b/app/src/main/res/xml/preferences_desktop.xml
@@ -70,6 +70,13 @@
             android:summary="@string/pref_summary__search_bar_base_uri"
             android:title="@string/pref_title__search_bar_base_uri" />
 
+        <CheckBoxPreference
+            android:defaultValue="false"
+            android:dependency="@string/pref_key__search_bar_enable"
+            android:key="@string/pref_key__search_bar_force_browser"
+            android:summary="@string/pref_summary__search_bar_force_browser"
+            android:title="@string/pref_title__search_bar_force_browser" />
+
     </PreferenceCategory>
 
     <PreferenceCategory android:title="@string/pref_title__color">

--- a/core/src/main/java/com/benny/openlauncher/core/activity/Home.java
+++ b/core/src/main/java/com/benny/openlauncher/core/activity/Home.java
@@ -404,7 +404,7 @@ public abstract class Home extends Activity implements Desktop.OnDesktopEditList
             public void onInternetSearch(String string) {
                 Intent intent = new Intent();
 
-                if (Tool.isIntentActionAvailable(getApplicationContext(), Intent.ACTION_WEB_SEARCH)) {
+                if (Tool.isIntentActionAvailable(getApplicationContext(), Intent.ACTION_WEB_SEARCH) && ! Setup.appSettings().getSearchBarForceBrowser()) {
                     intent.setAction(Intent.ACTION_WEB_SEARCH);
                     intent.putExtra(SearchManager.QUERY, string);
                 } else {

--- a/core/src/main/java/com/benny/openlauncher/core/interfaces/SettingsManager.java
+++ b/core/src/main/java/com/benny/openlauncher/core/interfaces/SettingsManager.java
@@ -50,6 +50,7 @@ public interface SettingsManager {
     // SearchBar
     boolean getSearchBarEnable();
     String getSearchBarBaseURI();
+    boolean getSearchBarForceBrowser();
     boolean isSearchBarTimeEnabled();
     SimpleDateFormat getUserDateFormat();
     boolean isResetSearchBarOnOpen();


### PR DESCRIPTION
As discussed in #159 this adds the option to always use the browser for online searches, even if there is a search app installed.