### PR TITLE
Fixed minibar background

### DIFF
--- a/app/src/main/java/com/benny/openlauncher/activity/Home.java
+++ b/app/src/main/java/com/benny/openlauncher/activity/Home.java
@@ -195,7 +195,6 @@ public class Home extends com.benny.openlauncher.core.activity.Home implements D
                 }
             }
         });
-        minibar.setBackgroundColor(AppSettings.get().getMinibarBackgroundColor());
         minibarBackground.setBackgroundColor(AppSettings.get().getMinibarBackgroundColor());
     }
 


### PR DESCRIPTION
Hello,

if you select transparent background for minibar, it ends up darker bellow the icons. This one line change fixes it. The problem was, that the background colour was set on two views and the colours added up.

Hope it helps,
Vasek