### PR TITLE
Add Rotate screen option for tablets

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -37,7 +37,6 @@
             android:configChanges="orientation|keyboard|screenSize"
             android:label="@string/app_name"
             android:launchMode="singleTask"
-            android:screenOrientation="portrait"
             android:stateNotNeeded="true"
             android:taskAffinity=""
             android:windowSoftInputMode="adjustNothing">

--- a/app/src/main/java/com/benny/openlauncher/activity/Home.java
+++ b/app/src/main/java/com/benny/openlauncher/activity/Home.java
@@ -3,6 +3,8 @@ package com.benny.openlauncher.activity;
 import android.Manifest;
 import android.content.Context;
 import android.content.Intent;
+import android.content.SharedPreferences;
+import android.content.pm.ActivityInfo;
 import android.content.pm.PackageManager;
 import android.database.ContentObserver;
 import android.database.Cursor;
@@ -11,7 +13,10 @@ import android.graphics.drawable.Drawable;
 import android.net.Uri;
 import android.os.Bundle;
 import android.os.Handler;
+import android.preference.Preference;
+import android.preference.PreferenceManager;
 import android.provider.CallLog;
+import android.provider.Settings;
 import android.support.annotation.NonNull;
 import android.support.v4.app.ActivityCompat;
 import android.support.v4.widget.DrawerLayout;
@@ -58,6 +63,7 @@ import butterknife.BindView;
 import butterknife.ButterKnife;
 import butterknife.Unbinder;
 import cat.ereza.customactivityoncrash.CustomActivityOnCrash;
+
 import net.gsantner.opoc.util.ContextUtils;
 
 public class Home extends com.benny.openlauncher.core.activity.Home implements DrawerLayout.DrawerListener {
@@ -532,5 +538,28 @@ public class Home extends com.benny.openlauncher.core.activity.Home implements D
         public void onChange(boolean selfChange, Uri uri) {
             logCallLog();
         }
+    }
+
+    @Override
+    protected void onResume() {
+        super.onResume();
+
+        boolean user = AppSettings.get().getBool(R.string.pref_key__desktop_rotate, false);
+        boolean system = false;
+        try {
+            system = Settings.System.getInt(getContentResolver(), Settings.System.ACCELEROMETER_ROTATION) == 1;
+        } catch (Settings.SettingNotFoundException e) {
+            Log.d(Home.class.getSimpleName(), "Unable to read settings", e);
+        }
+        boolean rotate;
+        if (getResources().getBoolean(R.bool.isTablet)) { // tables has no user option to disable rotate
+            rotate = system;
+        } else {
+            rotate = user && system;
+        }
+        if (rotate)
+            setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_SENSOR);
+        else
+            setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_PORTRAIT);
     }
 }

--- a/app/src/main/java/com/benny/openlauncher/activity/SettingsActivity.java
+++ b/app/src/main/java/com/benny/openlauncher/activity/SettingsActivity.java
@@ -10,6 +10,7 @@ import android.content.SharedPreferences;
 import android.content.pm.PackageManager;
 import android.os.Bundle;
 import android.preference.Preference;
+import android.preference.PreferenceCategory;
 import android.preference.PreferenceFragment;
 import android.preference.PreferenceScreen;
 import android.support.annotation.Nullable;
@@ -28,7 +29,7 @@ import com.benny.openlauncher.viewutil.DialogHelper;
 import butterknife.BindView;
 import butterknife.ButterKnife;
 
-public class SettingsActivity extends ThemeActivity{
+public class SettingsActivity extends ThemeActivity {
     @BindView(R.id.toolbar)
     protected Toolbar toolbar;
     protected static Context context;
@@ -436,6 +437,12 @@ public class SettingsActivity extends ThemeActivity{
             super.onCreate(savedInstances);
             getPreferenceManager().setSharedPreferencesName("app");
             addPreferencesFromResource(R.xml.preferences_miscellaneous);
+
+            if (getResources().getBoolean(R.bool.isTablet)) {
+                PreferenceCategory c = (PreferenceCategory) findPreference(getString(R.string.pref_key__cat_miscellaneous));
+                Preference p = c.findPreference(getString(R.string.pref_key__desktop_rotate));
+                c.removePreference(p);
+            }
         }
 
         @Override

--- a/app/src/main/res/values-sw600dp/tablet.xml
+++ b/app/src/main/res/values-sw600dp/tablet.xml
@@ -1,0 +1,3 @@
+<resources>
+    <bool name="isTablet">true</bool>
+</resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -87,6 +87,8 @@
     <string name="pref_summary__desktop_show_position_indicator">Show the page indicator below the desktop.</string>
     <string name="pref_title__desktop_show_label">Show Labels</string>
     <string name="pref_summary__desktop_show_label">Show item labels below their icons.</string>
+    <string name="pref_title__desktop_rotate">Roate</string>
+    <string name="pref_summary__desktop_rotate">Allow screen rotate.</string>
     <string name="pref_title__search_bar_base_uri">Search URI</string>
     <string name="pref_summary__search_bar_base_uri">Set the URI used for web searches.</string>
     <string name="pref_dialog__search_bar_base_uri">Enter the URI that should be used for web searches. The tag {query} can be used as
@@ -171,6 +173,7 @@
     <string name="pref_key__desktop_hide_grid" translatable="false">pref_key__hide_grid</string>
     <string name="pref_key__desktop_show_position_indicator" translatable="false">pref_key__desktop_show_position_indicator</string>
     <string name="pref_key__desktop_show_label" translatable="false">pref_key__desktop_show_label</string>
+    <string name="pref_key__desktop_rotate" translatable="false">pref_key__desktop_rotate</string>
     <string name="pref_key__search_bar_base_uri" translatable="false">pref_key__search_bar_base_uri</string>
     <string name="pref_key__search_bar_force_browser" translatable="false">pref_key__search_bar_force_browser</string>
     <string name="pref_key__desktop_background_color" translatable="false">pref_key__desktop_background_color</string>

--- a/app/src/main/res/values/tablet.xml
+++ b/app/src/main/res/values/tablet.xml
@@ -1,0 +1,3 @@
+<resources>
+    <bool name="isTablet">false</bool>
+</resources>

--- a/app/src/main/res/xml/preferences_miscellaneous.xml
+++ b/app/src/main/res/xml/preferences_miscellaneous.xml
@@ -3,7 +3,7 @@
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
                   xmlns:app="http://schemas.android.com/apk/res-auto">
 
-    <PreferenceCategory android:title="@string/pref_title__miscellaneous">
+    <PreferenceCategory android:title="@string/pref_title__miscellaneous" android:key="@string/pref_key__cat_miscellaneous">
 
         <!--suppress AndroidDomInspection -->
         <net.gsantner.opoc.ui.LanguagePreference
@@ -34,6 +34,12 @@
             android:key="@string/pref_key__theme"
             android:summary="@string/pref_summary__theme"
             android:title="@string/pref_title__theme" />
+
+        <CheckBoxPreference
+            android:defaultValue="false"
+            android:key="@string/pref_key__desktop_rotate"
+            android:summary="@string/pref_summary__desktop_rotate"
+            android:title="@string/pref_title__desktop_rotate" />
 
         <com.jaredrummler.android.colorpicker.ColorPreference
             android:defaultValue="@color/colorPrimary"


### PR DESCRIPTION
I add 'Rotate screen' option for tablets only, phones (sw600dp<) will have this option hidden. Uses system settings for rotate or portrait mode (same as Google Now Launcher)

#120