### PR TITLE
Prevent crashing just after boot

### DIFF
--- a/core/src/main/java/com/benny/openlauncher/core/activity/Home.java
+++ b/core/src/main/java/com/benny/openlauncher/core/activity/Home.java
@@ -296,6 +296,9 @@ public abstract class Home extends Activity implements Desktop.OnDesktopEditList
         Setup.appLoader().addUpdateListener(new AppUpdateListener<App>() {
             @Override
             public boolean onAppUpdated(List<App> apps) {
+                if (desktop == null)
+                    return false;
+
                 if (Setup.appSettings().getDesktopStyle() != Desktop.DesktopMode.SHOW_ALL_APPS) {
                     if (Setup.appSettings().isAppFirstLaunch()) {
                         Setup.appSettings().setAppFirstLaunch(false);

--- a/core/src/main/java/com/benny/openlauncher/core/widget/AppDrawerVertical.java
+++ b/core/src/main/java/com/benny/openlauncher/core/widget/AppDrawerVertical.java
@@ -76,7 +76,7 @@ public class AppDrawerVertical extends CardView {
 
     @Override
     protected void onConfigurationChanged(Configuration newConfig) {
-        if (apps == null) {
+        if (apps == null || layoutManager == null) {
             super.onConfigurationChanged(newConfig);
             return;
         }


### PR DESCRIPTION
These changes fix the crashing after boot, but the app still restarts after few seconds. I have no idea why that's happening (I haven't looked deep enough). I hope, the patch isn't just fixing symptoms of a bigger issue.

----

Fixes https://github.com/OpenLauncherTeam/openlauncher/issues/243
Also prevents this crash:

```
Build version: 0.5.5 
Build date: 1979-11-30 00:00:00 
Current date: 2017-10-01 22:24:19 
Device: Motorola Moto G (5) 

Stack trace: 
java.lang.NullPointerException: Attempt to invoke virtual method 'void android.support.v7.widget.GridLayoutManager.setSpanCount(int)' on a null object reference
at com.benny.openlauncher.core.widget.AppDrawerVertical.setPortraitValue(AppDrawerVertical.java:93)
at com.benny.openlauncher.core.widget.AppDrawerVertical.onConfigurationChanged(AppDrawerVertical.java:87)
at android.view.View.dispatchConfigurationChanged(View.java:10420)
at android.view.ViewGroup.dispatchConfigurationChanged(ViewGroup.java:1311)
at android.view.ViewGroup.dispatchConfigurationChanged(ViewGroup.java:1315)
at android.view.ViewGroup.dispatchConfigurationChanged(ViewGroup.java:1315)
at android.view.ViewGroup.dispatchConfigurationChanged(ViewGroup.java:1315)
at android.view.ViewGroup.dispatchConfigurationChanged(ViewGroup.java:1315)
at android.view.ViewGroup.dispatchConfigurationChanged(ViewGroup.java:1315)
at android.view.ViewGroup.dispatchConfigurationChanged(ViewGroup.java:1315)
at android.view.ViewGroup.dispatchConfigurationChanged(ViewGroup.java:1315)
at android.view.ViewRootImpl.updateConfiguration(ViewRootImpl.java:3349)
at android.view.ViewRootImpl.performTraversals(ViewRootImpl.java:1771)
at android.view.ViewRootImpl.doTraversal(ViewRootImpl.java:1258)
at android.view.ViewRootImpl$TraversalRunnable.run(ViewRootImpl.java:6348)
at android.view.Choreographer$CallbackRecord.run(Choreographer.java:871)
at android.view.Choreographer.doCallbacks(Choreographer.java:683)
at android.view.Choreographer.doFrame(Choreographer.java:619)
at android.view.Choreographer$FrameDisplayEventReceiver.run(Choreographer.java:857)
at android.os.Handler.handleCallback(Handler.java:751)
at android.os.Handler.dispatchMessage(Handler.java:95)
at android.os.Looper.loop(Looper.java:154)
at android.app.ActivityThread.main(ActivityThread.java:6123)
at java.lang.reflect.Method.invoke(Native Method)
at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:867)
at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:757)
```