### PR TITLE
Can not show Chinese Character properly

### DIFF
--- a/core/src/main/java/com/benny/openlauncher/core/widget/AppItemView.java
+++ b/core/src/main/java/com/benny/openlauncher/core/widget/AppItemView.java
@@ -191,8 +191,13 @@ public class AppItemView extends View implements Drawable.Callback, IconDrawer {
             // set start position manually if text container is too large
             float x = Math.max(8, (getWidth() - textContainer.width()) / 2f);
 
-            if (textContainer.width() > getWidth() && label.length() - 3 - charToTruncate > 0) {
-                canvas.drawText(label.substring(0, label.length() - 3 - charToTruncate) + "...", x, getHeight() - heightPadding, textPaint);
+            if (textContainer.width() + 8 > getWidth() && label.length() - charToTruncate > 0) {
+                String showLabel = label.substring(0, label.length() - charToTruncate);
+                do{
+                    textPaint.getTextBounds(showLabel + "...", 0, label.length() - charToTruncate + 3, textContainer);
+                }while(textContainer.width() + 8 > getWidth() && label.length() - (++charToTruncate) > 0);
+
+                canvas.drawText(label.substring(0, label.length() - charToTruncate) + "...", x, getHeight() - heightPadding, textPaint);
             } else {
                 canvas.drawText(label, x, getHeight() - heightPadding, textPaint);
             }


### PR DESCRIPTION
When the Label is long Chinese String, app list only show one Chinese character and "..." (screen size: 1920x1080, dpi 480). eg. "开...".
Actually, there is no need to -3 for "...", because one Chinese Character is wide enough to show "...".
So, I think it is better to find a good enough "charToTruncate" in a loop.