### PR TITLE
If user pressed home (in some app) the drawer hides

### DIFF
--- a/core/src/main/java/com/benny/openlauncher/core/activity/CoreHome.kt
+++ b/core/src/main/java/com/benny/openlauncher/core/activity/CoreHome.kt
@@ -905,7 +905,7 @@ abstract class CoreHome : Activity(), Desktop.OnDesktopEditListener, DesktopOpti
     }
 
     override fun onBackPressed() {
-        handleLauncherPause()
+        handleLauncherPause(false)
     }
 
     override fun onResume() {
@@ -923,12 +923,13 @@ abstract class CoreHome : Activity(), Desktop.OnDesktopEditListener, DesktopOpti
         launcher = this
         appWidgetHost?.startListening()
 
-        handleLauncherPause()
+        handleLauncherPause(intent.action == Intent.ACTION_MAIN)
+
         super.onResume()
     }
 
-    private fun handleLauncherPause() {
-        if (consumeNextResume) {
+    private fun handleLauncherPause(wasHomePressed: Boolean) {
+        if (consumeNextResume && !wasHomePressed) {
             consumeNextResume = false
             return
         }


### PR DESCRIPTION
If the user pressed home (in some app) the drawer hides, if the user pressed back it doesn't.

Fixes  #275.