### PR TITLE
Improve SearchBar (#404, language independent search)

### DIFF
--- a/app/src/main/java/com/benny/openlauncher/model/App.java
+++ b/app/src/main/java/com/benny/openlauncher/model/App.java
@@ -91,6 +91,6 @@ public class App {
     }
 
     public void setUniversalLabel(@Nullable String universalLabel) {
-        this._universalLabel = universalLabel;
+        _universalLabel = universalLabel;
     }
 }

--- a/app/src/main/java/com/benny/openlauncher/model/App.java
+++ b/app/src/main/java/com/benny/openlauncher/model/App.java
@@ -16,10 +16,6 @@ public class App {
     public Drawable _icon;
     public String _label;
 
-    /**
-     * App label for root locale.
-     * @see Locale#ROOT
-     */
     @Nullable public String _universalLabel;
 
     public String _packageName;
@@ -33,7 +29,7 @@ public class App {
 
         try {
             updateUniversalLabel(pm, info);
-            Log.d("AppModel", "Universal label " + _universalLabel);
+            Log.d("AppModel", "Universal label " + getUniversalLabel());
         } catch (Exception e) {
             Log.e("AppModel", "Cannot resolve universal label for " + _label, e);
         }
@@ -48,7 +44,7 @@ public class App {
         Resources resources = pm.getResourcesForApplication(appInfo);
         resources.updateConfiguration(config, null);
 
-        _universalLabel = resources.getString(appInfo.labelRes);
+        setUniversalLabel(resources.getString(appInfo.labelRes));
     }
 
     @Override
@@ -83,5 +79,18 @@ public class App {
 
     public String getComponentName() {
         return "ComponentInfo{" + _packageName + "/" + _className + "}";
+    }
+
+    /**
+     * App label for root locale.
+     * @see Locale#ROOT
+     */
+    @Nullable
+    public String getUniversalLabel() {
+        return _universalLabel;
+    }
+
+    public void setUniversalLabel(@Nullable String _universalLabel) {
+        this._universalLabel = _universalLabel;
     }
 }

--- a/app/src/main/java/com/benny/openlauncher/model/App.java
+++ b/app/src/main/java/com/benny/openlauncher/model/App.java
@@ -90,7 +90,7 @@ public class App {
         return _universalLabel;
     }
 
-    public void setUniversalLabel(@Nullable String _universalLabel) {
-        this._universalLabel = _universalLabel;
+    public void setUniversalLabel(@Nullable String universalLabel) {
+        this._universalLabel = universalLabel;
     }
 }

--- a/app/src/main/java/com/benny/openlauncher/model/App.java
+++ b/app/src/main/java/com/benny/openlauncher/model/App.java
@@ -1,13 +1,27 @@
 package com.benny.openlauncher.model;
 
+import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageManager;
 import android.content.pm.ResolveInfo;
 
+import android.content.res.Configuration;
+import android.content.res.Resources;
 import android.graphics.drawable.Drawable;
+import android.support.annotation.Nullable;
+import android.util.Log;
+
+import java.util.Locale;
 
 public class App {
     public Drawable _icon;
     public String _label;
+
+    /**
+     * App label for root locale.
+     * @see Locale#ROOT
+     */
+    @Nullable public String _universalLabel;
+
     public String _packageName;
     public String _className;
 
@@ -16,6 +30,25 @@ public class App {
         _label = info.loadLabel(pm).toString();
         _packageName = info.activityInfo.packageName;
         _className = info.activityInfo.name;
+
+        try {
+            updateUniversalLabel(pm, info);
+            Log.d("AppModel", "Universal label " + _universalLabel);
+        } catch (Exception e) {
+            Log.e("AppModel", "Cannot resolve universal label for " + _label, e);
+        }
+    }
+
+    private void updateUniversalLabel(PackageManager pm, ResolveInfo info) throws PackageManager.NameNotFoundException {
+        ApplicationInfo appInfo = info.activityInfo.applicationInfo;
+
+        Configuration config = new Configuration();
+        config.locale = Locale.ROOT;
+
+        Resources resources = pm.getResourcesForApplication(appInfo);
+        resources.updateConfiguration(config, null);
+
+        _universalLabel = resources.getString(appInfo.labelRes);
     }
 
     @Override

--- a/app/src/main/java/com/benny/openlauncher/viewutil/IconLabelItem.java
+++ b/app/src/main/java/com/benny/openlauncher/viewutil/IconLabelItem.java
@@ -22,6 +22,13 @@ public class IconLabelItem extends AbstractItem<IconLabelItem, IconLabelItem.Vie
 
     public Drawable _icon;
     public String _label;
+
+    /**
+     * Extra string for filtering/search purpose.
+     * Ex. root-locale app name (label) and Search Bar.
+     */
+    @Nullable public String _searchInfo;
+
     private View.OnLongClickListener _onLongClickListener;
     private View.OnClickListener _onClickListener;
 
@@ -67,6 +74,11 @@ public class IconLabelItem extends AbstractItem<IconLabelItem, IconLabelItem.Vie
         _label = label;
         _icon = icon;
         _forceSize = forceSize;
+    }
+
+    public IconLabelItem(Context context, Drawable icon, String label, @Nullable String searchInfo, int forceSize) {
+        this(context, icon, label, forceSize);
+        this._searchInfo = searchInfo;
     }
 
     public IconLabelItem withIconGravity(int iconGravity) {

--- a/app/src/main/java/com/benny/openlauncher/viewutil/IconLabelItem.java
+++ b/app/src/main/java/com/benny/openlauncher/viewutil/IconLabelItem.java
@@ -77,9 +77,7 @@ public class IconLabelItem extends AbstractItem<IconLabelItem, IconLabelItem.Vie
     }
 
     public IconLabelItem(Context context, Drawable icon, String label, @Nullable String searchInfo, int forceSize) {
-        _label = label;
-        _icon = icon;
-        _forceSize = forceSize;
+        this(context, icon, label, forceSize);
         _searchInfo = searchInfo;
     }
 

--- a/app/src/main/java/com/benny/openlauncher/viewutil/IconLabelItem.java
+++ b/app/src/main/java/com/benny/openlauncher/viewutil/IconLabelItem.java
@@ -77,8 +77,10 @@ public class IconLabelItem extends AbstractItem<IconLabelItem, IconLabelItem.Vie
     }
 
     public IconLabelItem(Context context, Drawable icon, String label, @Nullable String searchInfo, int forceSize) {
-        this(context, icon, label, forceSize);
-        this._searchInfo = searchInfo;
+        _label = label;
+        _icon = icon;
+        _forceSize = forceSize;
+        _searchInfo = searchInfo;
     }
 
     public IconLabelItem withIconGravity(int iconGravity) {

--- a/app/src/main/java/com/benny/openlauncher/widget/SearchBar.java
+++ b/app/src/main/java/com/benny/openlauncher/widget/SearchBar.java
@@ -271,7 +271,7 @@ public class SearchBar extends FrameLayout {
                 String s = constraint.toString();
                 if (s.isEmpty())
                     return true;
-                else if (item._label.toLowerCase().contains(s.toLowerCase()))
+                else if (!item._label.toLowerCase().contains(s.toLowerCase()))
                     return false;
                 else
                     return true;

--- a/app/src/main/java/com/benny/openlauncher/widget/SearchBar.java
+++ b/app/src/main/java/com/benny/openlauncher/widget/SearchBar.java
@@ -266,15 +266,20 @@ public class SearchBar extends FrameLayout {
         _adapter.getItemFilter().withFilterPredicate(new IItemAdapter.Predicate<IconLabelItem>() {
             @Override
             public boolean filter(IconLabelItem item, CharSequence constraint) {
-                if (item._label.equals(getContext().getString(R.string.search_online)))
+                if (item._label.equals(getContext().getString(R.string.search_online))) {
                     return false;
-                String s = constraint.toString();
-                if (s.isEmpty())
+                }
+
+                if (constraint.length() == 0) {
                     return true;
-                else if (!item._label.toLowerCase().contains(s.toLowerCase()))
-                    return false;
-                else
+                }
+
+                String s = constraint.toString().toLowerCase();
+                if (item._label.toLowerCase().contains(s)) {
                     return true;
+                }
+
+                return false;
             }
         });
 

--- a/app/src/main/java/com/benny/openlauncher/widget/SearchBar.java
+++ b/app/src/main/java/com/benny/openlauncher/widget/SearchBar.java
@@ -231,7 +231,7 @@ public class SearchBar extends FrameLayout {
                 for (int i = 0; i < apps.size(); i++) {
                     final App app = apps.get(i);
                     final int finalI = i;
-                    items.add(new IconLabelItem(getContext(), app.getIcon(), app.getLabel(), 36)
+                    items.add(new IconLabelItem(getContext(), app.getIcon(), app.getLabel(), app._universalLabel, 36)
                             .withIconGravity(Setup.appSettings().getSearchGridSize() > 1 && Setup.appSettings().getSearchLabelLines() == 0 ? Gravity.TOP : Gravity.START)
                             .withOnClickListener(new OnClickListener() {
                                 @Override
@@ -276,6 +276,10 @@ public class SearchBar extends FrameLayout {
 
                 String s = constraint.toString().toLowerCase();
                 if (item._label.toLowerCase().contains(s)) {
+                    return true;
+                }
+
+                if (item._searchInfo != null && item._searchInfo.toLowerCase().contains(s)) {
                     return true;
                 }
 

--- a/app/src/main/java/com/benny/openlauncher/widget/SearchBar.java
+++ b/app/src/main/java/com/benny/openlauncher/widget/SearchBar.java
@@ -231,7 +231,7 @@ public class SearchBar extends FrameLayout {
                 for (int i = 0; i < apps.size(); i++) {
                     final App app = apps.get(i);
                     final int finalI = i;
-                    items.add(new IconLabelItem(getContext(), app.getIcon(), app.getLabel(), app._universalLabel, 36)
+                    items.add(new IconLabelItem(getContext(), app.getIcon(), app.getLabel(), app.getUniversalLabel(), 36)
                             .withIconGravity(Setup.appSettings().getSearchGridSize() > 1 && Setup.appSettings().getSearchLabelLines() == 0 ? Gravity.TOP : Gravity.START)
                             .withOnClickListener(new OnClickListener() {
                                 @Override


### PR DESCRIPTION
1. Fixed #404 
2. Improved search/filtering in SearchBar: for search, a universal application name is now used, not just localized. See images below.


![screenshot_20180620-125423](https://user-images.githubusercontent.com/7098424/41636999-83609d5c-748c-11e8-8de3-45fc6b218645.png)
Before Search improvement. Oh ah! Another keymap required...  Only "Фонарик" app name available for us.

![screenshot_20180620-130024](https://user-images.githubusercontent.com/7098424/41637054-c6cfad80-748c-11e8-8977-5f55386ea353.png)
After Search improvement. We can use "flashlight" word, not only localized name!