### PR TITLE
Painting MoreInfoActivity's toolbar with primaryColor.

### DIFF
--- a/app/src/main/java/com/benny/openlauncher/activity/MoreInfoActivity.java
+++ b/app/src/main/java/com/benny/openlauncher/activity/MoreInfoActivity.java
@@ -12,8 +12,10 @@ public class MoreInfoActivity extends ThemeActivity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_more);
+
         Toolbar toolbar = findViewById(R.id.toolbar);
         setSupportActionBar(toolbar);
+        toolbar.setBackgroundColor(_appSettings.getPrimaryColor());
 
         getSupportActionBar().setDisplayHomeAsUpEnabled(true);
 


### PR DESCRIPTION
Noticed that MoreInfoActivity's toolbar wasn't painted with primaryColor. Fixed it.