### PR TITLE
cleanup `gradle build` errors

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     package="com.benny.openlauncher">
 
     <uses-permission android:name="android.permission.SET_WALLPAPER" />
@@ -7,7 +8,8 @@
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.VIBRATE" />
     <uses-permission android:name="android.permission.EXPAND_STATUS_BAR" />
-    <uses-permission android:name="android.permission.WRITE_SETTINGS"/>
+    <uses-permission android:name="android.permission.WRITE_SETTINGS"
+        tools:ignore="ProtectedPermissions" />
 
     <application
         android:name="com.benny.openlauncher.AppObject"

--- a/app/src/main/java/com/benny/openlauncher/util/LauncherAction.java
+++ b/app/src/main/java/com/benny/openlauncher/util/LauncherAction.java
@@ -51,6 +51,7 @@ public class LauncherAction {
         LauncherAction.RunAction(getActionItem(action), context);
     }
 
+    @SuppressWarnings("WrongConstant")
     public static void RunAction(ActionDisplayItem action, final Context context) {
         switch (action._action) {
             case EditMinibar:


### PR DESCRIPTION
1. First error is that the constant defined for notifacation dropdown is
not defined overall, adding a @SuppressWarnings('WrongConstant') fixes
this. Found fix @ https://stackoverflow.com/a/39923916

2. Second error is that the WRITE_SETTINGS permission is only available
for system applications. Fix is to ignore ProtectedPermissions (as it is
asked for properly on usage anyways). Found solution @
https://stackoverflow.com/a/34303770

---
First off thanks for a great project! I love the launcher and use it every-day. Best current open source launcher available.

I ran into some issues trying to `gradle build` from scratch -- got two errors, one recently added, so these changes fix that.

Ran into these issues first when starting to poke around for #283. More details are there.

I don't consider this worthy for adding to `CONTRIBUTORS.md` maybe will do so after a few more PRs roll in.

Hope this is helpful in some way. If you need any further changes, or don't consider this necessary, no worries, I can change anything with it. If you think it is not necessary to merge, that's fine with me too.

Thanks!