### PR TITLE
groups aren't clipped correctly on Android-P

### DIFF
--- a/app/src/main/java/com/benny/openlauncher/viewutil/GroupDrawable.java
+++ b/app/src/main/java/com/benny/openlauncher/viewutil/GroupDrawable.java
@@ -132,6 +132,8 @@ public class GroupDrawable extends Drawable {
         clip.addCircle(_iconSize / 2, _iconSize / 2, _iconSize / 2 - _outline, Path.Direction.CW);
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.P) {
             canvas.clipPath(clip, Region.Op.REPLACE);
+        } else {
+            canvas.clipPath(clip);
         }
 
         canvas.drawCircle(_iconSize / 2, _iconSize / 2, _iconSize / 2 - _outline, _paintInnerCircle);


### PR DESCRIPTION
Hey,

clipping for Grouped items wasn't working on Android-P. I don't have an earlier version to test on, so I left the existing code in place.

Cheers,
David