### PR TITLE
Use drawer column count to determine the gridsize of the search's grid layout

### DIFF
--- a/app/src/main/java/com/benny/openlauncher/widget/SearchBar.java
+++ b/app/src/main/java/com/benny/openlauncher/widget/SearchBar.java
@@ -321,7 +321,7 @@ public class SearchBar extends FrameLayout {
     }
 
     private void updateRecyclerViewLayoutManager() {
-        int gridSize = Setup.appSettings().getSearchUseGrid() ? 4 : 1;
+        int gridSize = Setup.appSettings().getSearchUseGrid() ? Setup.appSettings().getDrawerColumnCount() : 1;
         if (gridSize == 1) {
             _searchRecycler.setLayoutManager(new LinearLayoutManager(getContext(), LinearLayoutManager.VERTICAL, false));
             updateList(Gravity.START, Gravity.CENTER_VERTICAL);


### PR DESCRIPTION
# Rational
While the column count of the drawer, dock, and desktop is configurable, the grid layout of the search results view stays the same (i.e. 4).
Especially on larger screens, where the user might increase the columns and rows of the dock and drawer to display more apps, this results in a weirdly non-uniform look.

First thought about an option (will be implemented on request) for the column count of the search results view, but I think most people would set it to the same value as the drawer column count.

This PR will adjust the search results column count to the drawer's column count. Nothing fancy.

<!-- 

Hello, and thanks for contributing!

Please always auto-reformat code before creating a pull request. In Android Studio, right click the java file and select reformat, then check the first two options. After creating the request, please wait patiently until somebody from the team has time to review the changes.

## Contributors
Feel free to add yourself to the list of contributors! When adding your information to the `CONTRIBUTORS.md` file, please use the following format.

Schema:  **[Name](Reference)**<br/>~° Text

Where:
  * Name: username, full name
  * Reference: email, website
  * Text: information about your contribution

Example:
* **[Nice Guy](http://niceguy.web)**<br/>~° German localization

-->
