### PR TITLE
Fix bug where icons remain in a flawed state after disbanding a group

### DIFF
--- a/app/src/main/java/com/benny/openlauncher/widget/GroupPopupView.java
+++ b/app/src/main/java/com/benny/openlauncher/widget/GroupPopupView.java
@@ -306,7 +306,7 @@ public class GroupPopupView extends RevealFrameLayout {
                 // update db
                 HomeActivity._db.saveItem(item);
                 HomeActivity._db.saveItem(item, ItemState.Visible);
-                HomeActivity._db.deleteItem(currentItem, true);
+                HomeActivity._db.deleteItem(currentItem, false);
 
                 // update launcher
                 callback.removeItem(currentView, false);


### PR DESCRIPTION
# Rational
This PR fixes an issue with disbanding groups under some circumstances:

![disband_group](https://user-images.githubusercontent.com/24757415/72004634-146fdc80-324c-11ea-8d9c-a06791d6b6dd.gif)

When you create a group and disband it (later), the item on the group's position remains in a flawed state. This is due to a little bug related to the removal of the group entity: While the last item in the group is correctly created to replace the group entity, the flag *deleteSubItems=true* will delete the newly created item on the database layer because it still holds the reference and leaves it in a flawed state.
When you group another item with the flawed item *without moving it first (since this will create a new entry in the database)*, the `saveItem()` function (in DatabaseHelper.java) will silently fail to update the flawed item.
When removing an item in the *flawed group*, the code can't handle the weird state of the flawed item resulting in the issue shown above.

This PR fixes this issue and other display errors related to this (e.g. empty groups or groups with only one item).



<!-- 

Hello, and thanks for contributing!

Please always auto-reformat code before creating a pull request. In Android Studio, right click the java file and select reformat, then check the first two options. After creating the request, please wait patiently until somebody from the team has time to review the changes.

## Contributors
Feel free to add yourself to the list of contributors! When adding your information to the `CONTRIBUTORS.md` file, please use the following format.

Schema:  **[Name](Reference)**<br/>~° Text

Where:
  * Name: username, full name
  * Reference: email, website
  * Text: information about your contribution

Example:
* **[Nice Guy](http://niceguy.web)**<br/>~° German localization

-->
