### PR TITLE
Fix several bugs related to item position values of group items

### DIFF
--- a/app/src/main/java/com/benny/openlauncher/activity/homeparts/HpItemOption.java
+++ b/app/src/main/java/com/benny/openlauncher/activity/homeparts/HpItemOption.java
@@ -38,7 +38,10 @@ public class HpItemOption implements DialogListener.OnEditDialogListener {
 
     public final void onRemoveItem(@NonNull Item item) {
         View coordinateToChildView;
-        if (item._location.equals(ItemPosition.Desktop)) {
+        if (item._location.equals(ItemPosition.Group)) {
+            Tool.toast(_homeActivity, R.string.toast_remove_from_group_first);
+            return;
+        } else if (item._location.equals(ItemPosition.Desktop)) {
             Desktop desktop = _homeActivity.getDesktop();
             coordinateToChildView = desktop.getCurrentPage().coordinateToChildView(new Point(item._x, item._y));
             desktop.removeItem(coordinateToChildView, true);
@@ -87,7 +90,9 @@ public class HpItemOption implements DialogListener.OnEditDialogListener {
         Setup.dataManager().saveItem(_item);
         Point point = new Point(_item._x, _item._y);
 
-        if (_item._location.equals(ItemPosition.Desktop)) {
+        if (_item._location.equals(ItemPosition.Group)) {
+            return;
+        } else if (_item._location.equals(ItemPosition.Desktop)) {
             Desktop desktop = _homeActivity.getDesktop();
             desktop.removeItem(desktop.getCurrentPage().coordinateToChildView(point), false);
             desktop.addItemToCell(_item, _item._x, _item._y);

--- a/app/src/main/java/com/benny/openlauncher/util/Definitions.java
+++ b/app/src/main/java/com/benny/openlauncher/util/Definitions.java
@@ -13,7 +13,8 @@ public class Definitions {
     // enum ordinal used for db
     public enum ItemPosition {
         Dock,
-        Desktop
+        Desktop,
+        Group
     }
 
     public enum ItemState {

--- a/app/src/main/java/com/benny/openlauncher/widget/Desktop.java
+++ b/app/src/main/java/com/benny/openlauncher/widget/Desktop.java
@@ -71,11 +71,13 @@ public final class Desktop extends ViewPager implements DesktopCallback {
                             if (Type.APP.equals(dropItem._type) || Type.SHORTCUT.equals(dropItem._type)) {
                                 parent.removeView(itemView);
                                 Item group = Item.newGroupItem();
+                                item._location = ItemPosition.Group;
+                                dropItem._location = ItemPosition.Group;
                                 group.getGroupItems().add(item);
                                 group.getGroupItems().add(dropItem);
                                 group._x = item._x;
                                 group._y = item._y;
-                                HomeActivity._db.saveItem(dropItem, page, itemPosition);
+                                HomeActivity._db.saveItem(dropItem, page, ItemPosition.Group);
                                 HomeActivity._db.saveItem(item, ItemState.Hidden);
                                 HomeActivity._db.saveItem(dropItem, ItemState.Hidden);
                                 HomeActivity._db.saveItem(group, page, itemPosition);
@@ -90,8 +92,9 @@ public final class Desktop extends ViewPager implements DesktopCallback {
                         case GROUP:
                             if ((Item.Type.APP.equals(dropItem._type) || Type.SHORTCUT.equals(dropItem._type)) && item.getGroupItems().size() < GroupPopupView.GroupDef._maxItem) {
                                 parent.removeView(itemView);
+                                dropItem._location = ItemPosition.Group;
                                 item.getGroupItems().add(dropItem);
-                                HomeActivity._db.saveItem(dropItem, page, itemPosition);
+                                HomeActivity._db.saveItem(dropItem, page, ItemPosition.Group);
                                 HomeActivity._db.saveItem(dropItem, ItemState.Hidden);
                                 HomeActivity._db.saveItem(item, page, itemPosition);
                                 callback.addItemToPage(item, page);

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -250,4 +250,5 @@
     <string name="toast_backup_success">Backup completed.</string>
     <string name="toast_backup_error">Something went wrong.</string>
     <string name="toast_icon_pack_error">Please read access for external storage.</string>
+    <string name="toast_remove_from_group_first">Remove item from group first.</string>
 </resources>


### PR DESCRIPTION
*There's some guessing here when explaining the cause of the issues because I'm not really familiar with the implementation. Don't beat me.*

# Rational
The overall handling of group items seems somewhat error-prone and results in several issues like https://github.com/OpenLauncherTeam/openlauncher/pull/551.
This PR fixes a problem with removing and renaming items within a group (the captures don't clearly show the main point: when dragging, instead of removing the item and placing it on outside of the group, it's placed again within the group).

## `NullPointerException` when removing an item
![remove_withingroup](https://user-images.githubusercontent.com/24757415/72011233-afbb7e80-3259-11ea-8e5a-d17e32da6cb4.gif)
This is due to the `_location` of an item is sometimes not set properly. When dragging it directly from the drawer and placing it in the group, `_location` of the item is `null`. When dragging an group item and dropping it directly in the group again, `_location` is `null`.
The flawed group state described in https://github.com/OpenLauncherTeam/openlauncher/pull/551 can also lead to items, where the `_location` is `null`.
This is problematic when you want to remove an item, because the `_location` comparison in https://github.com/OpenLauncherTeam/openlauncher/blob/fd31da6e349101f3fc7755955fbf33ef8eabea15/app/src/main/java/com/benny/openlauncher/activity/homeparts/HpItemOption.java#L41 throws a `NullPointerException`.

Unfortunately, if `_location` is set correctly, https://github.com/OpenLauncherTeam/openlauncher/blob/fd31da6e349101f3fc7755955fbf33ef8eabea15/app/src/main/java/com/benny/openlauncher/activity/homeparts/HpItemOption.java#L44 will fail with a `NullPointerException`.
Same goes for renaming items.

## Deleting first item 'deletes'\* the whole group
\* not really, but it removes it till you restart OpenLauncher
![removefirst_ingroup](https://user-images.githubusercontent.com/24757415/72011811-e5ad3280-325a-11ea-8d9c-1acaf5c98bbd.gif)
This seems due to the the first item and the group entity share the same `_x`-, `_y` value. When deleting, the routine removes the item correctly on the database layer but entirely from the desktop till it's redraw (e.g. restarting OpenLauncher).


This PR introduces `ItemPosition.Group` do distinguish between items, which are not problematic to delete or rename with the current implementation, and items, which are error-prone in this case.
Items which are part of a group will have `_location` set to `ItemPosition.Group` by default (to circumvent `null` values).
Since removing an item from within a group causes a lot of errors, this is now prohibited: You must first remove the item from the group before removing it (this is not the best solution, but the simplest).
Renaming an item will just skip the remove-and-add part. This seems to work here.

There are still some visual glitches under rare circumstances. I'll fix them, if I encounter one :fireworks: .


<!-- 

Hello, and thanks for contributing!

Please always auto-reformat code before creating a pull request. In Android Studio, right click the java file and select reformat, then check the first two options. After creating the request, please wait patiently until somebody from the team has time to review the changes.

## Contributors
Feel free to add yourself to the list of contributors! When adding your information to the `CONTRIBUTORS.md` file, please use the following format.

Schema:  **[Name](Reference)**<br/>~° Text

Where:
  * Name: username, full name
  * Reference: email, website
  * Text: information about your contribution

Example:
* **[Nice Guy](http://niceguy.web)**<br/>~° German localization

-->
