### PR TITLE
Run correct activity when starting app with multiple activities

### DIFF
--- a/app/src/main/java/com/benny/openlauncher/activity/HomeActivity.java
+++ b/app/src/main/java/com/benny/openlauncher/activity/HomeActivity.java
@@ -346,7 +346,10 @@ public final class HomeActivity extends Activity implements OnDesktopEditListene
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && app._userHandle != null) {
                 LauncherApps launcherApps = (LauncherApps) context.getSystemService(Context.LAUNCHER_APPS_SERVICE);
                 List<LauncherActivityInfo> activities = launcherApps.getActivityList(app.getPackageName(), app._userHandle);
-                launcherApps.startMainActivity(activities.get(0).getComponentName(), app._userHandle, null, getActivityAnimationOpts(view));
+                for (int intent = 0; intent < activities.size(); intent++) {
+                    if (app.getComponentName().equals(activities.get(intent).getComponentName().toString()))
+                        launcherApps.startMainActivity(activities.get(intent).getComponentName(), app._userHandle, null, getActivityAnimationOpts(view));
+                }
             } else {
                 Intent intent = Tool.getIntentFromApp(app);
                 context.startActivity(intent, getActivityAnimationOpts(view));


### PR DESCRIPTION
# Rational

@hobleyd's PR (https://github.com/OpenLauncherTeam/openlauncher/pull/538) introduced the correct representation of apps with multiple activities (thanks!) but couldn't figure out how to start the intended activity.

This PR completes @hobleyd's PR and fixes this issue.

<!-- 

Hello, and thanks for contributing!

Please always auto-reformat code before creating a pull request. In Android Studio, right click the java file and select reformat, then check the first two options. After creating the request, please wait patiently until somebody from the team has time to review the changes.

## Contributors
Feel free to add yourself to the list of contributors! When adding your information to the `CONTRIBUTORS.md` file, please use the following format.

Schema:  **[Name](Reference)**<br/>~° Text

Where:
  * Name: username, full name
  * Reference: email, website
  * Text: information about your contribution

Example:
* **[Nice Guy](http://niceguy.web)**<br/>~° German localization

-->
