### PR TITLE
Implement update when item is remove from group with >2 items. Fixes visual glitch.

### DIFF
--- a/app/src/main/java/com/benny/openlauncher/widget/GroupPopupView.java
+++ b/app/src/main/java/com/benny/openlauncher/widget/GroupPopupView.java
@@ -128,6 +128,7 @@ public class GroupPopupView extends RevealFrameLayout {
 
                         collapse();
 
+                        // update group icon or
                         // convert group item into app item if there is only one item left
                         updateItem(callback, item, itemView);
                         return true;
@@ -312,6 +313,9 @@ public class GroupPopupView extends RevealFrameLayout {
                 callback.removeItem(currentView, false);
                 callback.addItemToCell(item, item.getX(), item.getY());
             }
+        } else {
+            callback.removeItem(currentView, false);
+            callback.addItemToCell(currentItem, currentItem.getX(), currentItem.getY());
         }
     }
 


### PR DESCRIPTION
# Rational
![update_group_view](https://user-images.githubusercontent.com/24757415/72166229-25922800-33c9-11ea-938a-dde9c3fd1a76.gif)
*Sorry, Peek is broken :/*

When removing on item from a group with >2 items, the group icon is not updated properly still shows the removed icon. This is due to the group is never updated properly except when the whole desktop is redrawn.

This PR fixes this issue by executing an update when `(currentItem.getGroupItems().size() != 1)`.


<!-- 

Hello, and thanks for contributing!

Please always auto-reformat code before creating a pull request. In Android Studio, right click the java file and select reformat, then check the first two options. After creating the request, please wait patiently until somebody from the team has time to review the changes.

## Contributors
Feel free to add yourself to the list of contributors! When adding your information to the `CONTRIBUTORS.md` file, please use the following format.

Schema:  **[Name](Reference)**<br/>~° Text

Where:
  * Name: username, full name
  * Reference: email, website
  * Text: information about your contribution

Example:
* **[Nice Guy](http://niceguy.web)**<br/>~° German localization

-->
