### PR TITLE
Fix bug where '_location' is not properly updated introduced with  https://github.com/OpenLauncherTeam/openlauncher/pull/552

### DIFF
--- a/app/src/main/java/com/benny/openlauncher/widget/GroupPopupView.java
+++ b/app/src/main/java/com/benny/openlauncher/widget/GroupPopupView.java
@@ -302,9 +302,11 @@ public class GroupPopupView extends RevealFrameLayout {
                 Item item = HomeActivity._db.getItem(currentItem.getGroupItems().get(0).getId());
                 item.setX(currentItem.getX());
                 item.setY(currentItem.getY());
+                item._location = ItemPosition.Desktop;
 
                 // update db
                 HomeActivity._db.saveItem(item);
+                HomeActivity._db.saveItem(item, HomeActivity._launcher.getDesktop().getCurrentItem(), ItemPosition.Desktop);
                 HomeActivity._db.saveItem(item, ItemState.Visible);
                 HomeActivity._db.deleteItem(currentItem, false);
 


### PR DESCRIPTION
# Rational

There's a small bug introduced with  https://github.com/OpenLauncherTeam/openlauncher/pull/552, where the `_location` is not properly updated after disbanding a group resulting in disappearing icons.

## Reproduce without this PR
1. Create group with two items (both items have `_location = ItemPosition.Group`
2. Remove one item from the group so group gets disbanded
    - removed item has `_location = ItemPosition.Desktop`
    - last item of group still has `_location = ItemPosition.Group` despite it's now a common icon
3. Redraw/Restart desktop
    - last item disappeared

<!-- 

Hello, and thanks for contributing!

Please always auto-reformat code before creating a pull request. In Android Studio, right click the java file and select reformat, then check the first two options. After creating the request, please wait patiently until somebody from the team has time to review the changes.

## Contributors
Feel free to add yourself to the list of contributors! When adding your information to the `CONTRIBUTORS.md` file, please use the following format.

Schema:  **[Name](Reference)**<br/>~° Text

Where:
  * Name: username, full name
  * Reference: email, website
  * Text: information about your contribution

Example:
* **[Nice Guy](http://niceguy.web)**<br/>~° German localization

-->
