### PR TITLE
Fix NullPointerException when restoring backup

### DIFF
--- a/app/src/main/java/com/benny/openlauncher/widget/ColorPreferenceCategory.java
+++ b/app/src/main/java/com/benny/openlauncher/widget/ColorPreferenceCategory.java
@@ -6,7 +6,7 @@ import android.support.v7.preference.PreferenceViewHolder;
 import android.util.AttributeSet;
 import android.widget.TextView;
 
-import com.benny.openlauncher.manager.Setup;
+import com.benny.openlauncher.util.AppSettings;
 
 public class ColorPreferenceCategory extends PreferenceCategory {
     public ColorPreferenceCategory(Context context) {
@@ -25,6 +25,6 @@ public class ColorPreferenceCategory extends PreferenceCategory {
     public void onBindViewHolder(PreferenceViewHolder holder) {
         super.onBindViewHolder(holder);
         TextView titleView = (TextView) holder.findViewById(android.R.id.title);
-        titleView.setTextColor(Setup.appSettings().getPrimaryColor());
+        titleView.setTextColor(AppSettings.get().getPrimaryColor());
     }
 }


### PR DESCRIPTION
*Non-breaking, but an improvement*

There's a minor issue when restoring a backup, where `Setup` is not initialized for whatever reason.
Instead of getting the  `AppSettings` through the uninitialized `Setup` reference , we can access `AppSettings` directly. It's static anyway and never requires cumbersome initialization.
```
    java.lang.RuntimeException: Setup has not been initialised!
        at com.benny.openlauncher.manager.Setup.get(Setup.java:25)
        at com.benny.openlauncher.manager.Setup.appSettings(Setup.java:35)
        at com.benny.openlauncher.widget.ColorPreferenceCategory.onBindViewHolder(ColorPreferenceCategory.java:30)
        at android.support.v7.preference.PreferenceGroupAdapter.onBindViewHolder(PreferenceGroupAdapter.java:381)
        at android.support.v7.preference.PreferenceGroupAdapter.onBindViewHolder(PreferenceGroupAdapter.java:45)
        at android.support.v7.widget.RecyclerView$Adapter.onBindViewHolder(RecyclerView.java:6781)
...
```
*after restoring a backup and app is restarted*
<!-- 

Hello, and thanks for contributing!

Please always auto-reformat code before creating a pull request. In Android Studio, right click the java file and select reformat, then check the first two options. After creating the request, please wait patiently until somebody from the team has time to review the changes.

## Contributors
Feel free to add yourself to the list of contributors! When adding your information to the `CONTRIBUTORS.md` file, please use the following format.

Schema:  **[Name](Reference)**<br/>~° Text

Where:
  * Name: username, full name
  * Reference: email, website
  * Text: information about your contribution

Example:
* **[Nice Guy](http://niceguy.web)**<br/>~° German localization

-->
