### PR TITLE
[Fixes #523] Remove uninstalled or hidden apps from groups. !Requires #580

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -253,4 +253,5 @@
     <string name="toast_database_deleted">Database deleted.</string>
     <string name="toast_icon_pack_error">Please read access for external storage.</string>
     <string name="toast_remove_from_group_first">Remove item from group first.</string>
+    <string name="toast_update_group_due_to_missing_items">Uninstalled or hidden apps where removed from this group.</string>
 </resources>


### PR DESCRIPTION
*Fixes: https://github.com/OpenLauncherTeam/openlauncher/issues/523* (@just-Nob may tell if this also fixes the F-Droid updates)


# Rational

According to https://github.com/OpenLauncherTeam/openlauncher/issues/523 groups are currently unable to handle missing items (ie. uninstalled or hidden apps).

This PR fixes this issue by removing missing items.

![update_group](https://user-images.githubusercontent.com/24757415/72459130-62e02680-37ca-11ea-9288-696abec9b06d.gif)

## Notes
1. Group is not updated automatically after hiding/uninstalling an app.
    - This may be implemented in the future but requires more effort. Currently, we have to deal with the broken group icons till the user clicks on it.
2. When app is unhidden again, it does not appear in it previous groups.
    - People my expect previously hidden apps to appear in their groups again but the current implementation doesn't allow this, because it introduces several new issues like stacked icons, seemingly empty groups, or oversized group popups.

<!-- 

Hello, and thanks for contributing!

Please always auto-reformat code before creating a pull request. In Android Studio, right click the java file and select reformat, then check the first two options. After creating the request, please wait patiently until somebody from the team has time to review the changes.

## Contributors
Feel free to add yourself to the list of contributors! When adding your information to the `CONTRIBUTORS.md` file, please use the following format.

Schema:  **[Name](Reference)**<br/>~° Text

Where:
  * Name: username, full name
  * Reference: email, website
  * Text: information about your contribution

Example:
* **[Nice Guy](http://niceguy.web)**<br/>~° German localization

-->
