### PR TITLE
Improve app manager async task to fix possible race condition

### DIFF
--- a/app/src/main/java/com/benny/openlauncher/util/AppManager.java
+++ b/app/src/main/java/com/benny/openlauncher/util/AppManager.java
@@ -141,20 +141,20 @@ public class AppManager {
     }
 
     private class AsyncGetApps extends AsyncTask {
-        private List<App> _appsTemp;
-        private List<App> _nonFilteredAppsTemp;
+        private List<App> appsTemp;
+        private List<App> nonFilteredAppsTemp;
 
         @Override
         protected void onPreExecute() {
-            _appsTemp = new ArrayList<>();
-            _nonFilteredAppsTemp = new ArrayList<>();
+            appsTemp = new ArrayList<>();
+            nonFilteredAppsTemp = new ArrayList<>();
             super.onPreExecute();
         }
 
         @Override
         protected void onCancelled() {
-            _appsTemp = null;
-            _nonFilteredAppsTemp = null;
+            appsTemp = null;
+            nonFilteredAppsTemp = null;
             super.onCancelled();
         }
 
@@ -172,7 +172,7 @@ public class AppManager {
                         app._userHandle = userHandle;
 
                         LOG.debug("adding work profile to non filtered list: {}, {}, {}", app._label, app._packageName, app._className);
-                        _nonFilteredAppsTemp.add(app);
+                        nonFilteredAppsTemp.add(app);
                     }
                 }
             } else {
@@ -183,12 +183,12 @@ public class AppManager {
                     App app = new App(_packageManager, info);
 
                     LOG.debug("adding app to non filtered list: {}, {}, {}", app._label,  app._packageName, app._className);
-                    _nonFilteredAppsTemp.add(app);
+                    nonFilteredAppsTemp.add(app);
                 }
             }
 
             // sort the apps by label here
-            Collections.sort(_nonFilteredAppsTemp, new Comparator<App>() {
+            Collections.sort(nonFilteredAppsTemp, new Comparator<App>() {
                 @Override
                 public int compare(App one, App two) {
                     return Collator.getInstance().compare(one._label, two._label);
@@ -197,37 +197,37 @@ public class AppManager {
 
             List<String> hiddenList = AppSettings.get().getHiddenAppsList();
             if (hiddenList != null) {
-                for (int i = 0; i < _nonFilteredAppsTemp.size(); i++) {
+                for (int i = 0; i < nonFilteredAppsTemp.size(); i++) {
                     boolean shouldGetAway = false;
                     for (String hidItemRaw : hiddenList) {
-                        if ((_nonFilteredAppsTemp.get(i).getComponentName()).equals(hidItemRaw)) {
+                        if ((nonFilteredAppsTemp.get(i).getComponentName()).equals(hidItemRaw)) {
                             shouldGetAway = true;
                             break;
                         }
                     }
                     if (!shouldGetAway) {
-                        _appsTemp.add(_nonFilteredAppsTemp.get(i));
+                        appsTemp.add(nonFilteredAppsTemp.get(i));
                     }
                 }
             } else {
-                _appsTemp.addAll(_nonFilteredAppsTemp);
+                appsTemp.addAll(nonFilteredAppsTemp);
             }
 
             AppSettings appSettings = AppSettings.get();
             if (!appSettings.getIconPack().isEmpty() && Tool.isPackageInstalled(appSettings.getIconPack(), _packageManager)) {
-                IconPackHelper.applyIconPack(AppManager.this, Tool.dp2px(appSettings.getIconSize()), appSettings.getIconPack(), _appsTemp);
+                IconPackHelper.applyIconPack(AppManager.this, Tool.dp2px(appSettings.getIconSize()), appSettings.getIconPack(), appsTemp);
             }
             return null;
         }
 
         @Override
         protected void onPostExecute(Object result) {
-            List<App> removed = getRemovedApps(_apps, _appsTemp);
+            List<App> removed = getRemovedApps(_apps, appsTemp);
 
-            _apps = _appsTemp;
-            _nonFilteredApps = _nonFilteredAppsTemp;
+            _apps = appsTemp;
+            _nonFilteredApps = nonFilteredAppsTemp;
 
-            notifyUpdateListeners(_appsTemp);
+            notifyUpdateListeners(appsTemp);
 
             if (removed.size() > 0) {
                 notifyRemoveListeners(removed);

--- a/app/src/main/java/com/benny/openlauncher/util/AppManager.java
+++ b/app/src/main/java/com/benny/openlauncher/util/AppManager.java
@@ -222,9 +222,13 @@ public class AppManager {
 
         @Override
         protected void onPostExecute(Object result) {
+            List<App> removed = getRemovedApps(_apps, _appsTemp);
+
+            _apps = _appsTemp;
+            _nonFilteredApps = _nonFilteredAppsTemp;
+
             notifyUpdateListeners(_appsTemp);
 
-            List<App> removed = getRemovedApps(_apps, _appsTemp);
             if (removed.size() > 0) {
                 notifyRemoveListeners(removed);
             }
@@ -234,9 +238,6 @@ public class AppManager {
                 if (_context instanceof HomeActivity)
                     ((HomeActivity) _context).recreate();
             }
-
-            _apps = _appsTemp;
-            _nonFilteredApps = _nonFilteredAppsTemp;
 
             super.onPostExecute(result);
         }


### PR DESCRIPTION
To fix a possible race condition mentioned in https://github.com/OpenLauncherTeam/openlauncher/pull/561 I've refactored the `AppManager.java`'s `AsyncGetApps` task.

All global variables modified by `doInBackground()` are replaced by temporary variables. New assignments of global variables are done in `onPostExecute()` which is executed in the main thread.

<!-- 

Hello, and thanks for contributing!

Please always auto-reformat code before creating a pull request. In Android Studio, right click the java file and select reformat, then check the first two options. After creating the request, please wait patiently until somebody from the team has time to review the changes.

## Contributors
Feel free to add yourself to the list of contributors! When adding your information to the `CONTRIBUTORS.md` file, please use the following format.

Schema:  **[Name](Reference)**<br/>~° Text

Where:
  * Name: username, full name
  * Reference: email, website
  * Text: information about your contribution

Example:
* **[Nice Guy](http://niceguy.web)**<br/>~° German localization

-->
