### PR TITLE
Clean accent in search bar filtering

### DIFF
--- a/app/src/main/java/com/benny/openlauncher/widget/SearchBar.java
+++ b/app/src/main/java/com/benny/openlauncher/widget/SearchBar.java
@@ -49,6 +49,8 @@ import org.threeten.bp.ZonedDateTime;
 import org.threeten.bp.format.DateTimeFormatter;
 
 import java.sql.Date;
+import java.text.Normalizer;
+import java.text.Normalizer.Form;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -259,12 +261,16 @@ public class SearchBar extends FrameLayout {
                 }
 
                 String s = constraint.toString().toLowerCase();
+                s = Normalizer.normalize(s, Form.NFD).replaceAll("\\p{InCombiningDiacriticalMarks}+", "");
+                String itemLabel = item._label.toLowerCase();
+                itemLabel = Normalizer.normalize(itemLabel, Form.NFD).replaceAll("\\p{InCombiningDiacriticalMarks}+", "");
+
                 if (Setup.appSettings().getSearchBarStartsWith()) {
-                    if (item._label.toLowerCase().startsWith(s)) {
+                    if (itemLabel.startsWith(s)) {
                         return true;
                     }
                 } else {
-                    if (item._label.toLowerCase().contains(s)) {
+                    if (itemLabel.contains(s)) {
                         return true;
                     }
                 }


### PR DESCRIPTION
Based on this article https://www.drillio.com/en/2011/java-remove-accent-diacritic/, remove accent in search bar filtering to ease the search of application.
e.g.: search for 'meteo' for application 'météo'