### PR TITLE
Make PWAs installable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+
+/.vscode
+.project
+
 # Common
 *~*
 tmp/

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -88,7 +88,7 @@
             </intent-filter>
         </activity>
         <activity
-            android:name="com.benny.openlauncher.activity.AddShortCutActivity"
+            android:name="com.benny.openlauncher.activity.AddShortcutActivity"
             android:autoRemoveFromRecents="true"
             android:excludeFromRecents="true"
             android:label="@string/app_name"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -87,6 +87,16 @@
                 <category android:name="android.intent.category.DEFAULT" />
             </intent-filter>
         </activity>
+        <activity
+            android:name="com.benny.openlauncher.activity.AddShortCutActivity"
+            android:autoRemoveFromRecents="true"
+            android:excludeFromRecents="true"
+            android:label="@string/app_name"
+            android:theme="@style/FilePickerTheme">
+            <intent-filter>
+                <action android:name="android.content.pm.action.CONFIRM_PIN_SHORTCUT" />
+            </intent-filter>
+        </activity>
 
         <receiver
             android:name="com.benny.openlauncher.receivers.DeviceAdminReceiver"

--- a/app/src/main/java/com/benny/openlauncher/activity/AddShortcutActivity.java
+++ b/app/src/main/java/com/benny/openlauncher/activity/AddShortcutActivity.java
@@ -2,11 +2,22 @@ package com.benny.openlauncher.activity;
 
 import android.app.Activity;
 import android.content.Context;
+import android.content.Intent; 
 import android.content.pm.LauncherApps;
+import android.content.pm.ShortcutInfo; 
+import android.graphics.Point;
+import android.graphics.drawable.Drawable;
 import android.os.Build;
 import android.os.Bundle;
+import android.util.Log;
 
-public class AddItemActivity extends Activity {
+import com.benny.openlauncher.AppObject;
+import com.benny.openlauncher.R;
+import com.benny.openlauncher.model.Item;
+import com.benny.openlauncher.util.Definitions;
+import com.benny.openlauncher.util.Tool;
+
+public class AddShortcutActivity extends Activity {
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -21,19 +32,20 @@ public class AddItemActivity extends Activity {
 
             if (request.getRequestType() == LauncherApps.PinItemRequest.REQUEST_TYPE_SHORTCUT) {
                 
-                ShortcutInfoCompat info = new ShortcutInfoCompat(request.getShortcutInfo());
+                ShortcutInfo info = request.getShortcutInfo();
                 String shortcutLabel = info.getShortLabel().toString();
-                Intent shortcutIntent = info.makeIntent();
-                Drawable shortcutIcon = null;
+                Intent shortcutIntent = new Intent(Intent.ACTION_MAIN)
+                    .setComponent(info.getActivity())
+                    .setPackage(info.getPackage())
+                    .setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_RESET_TASK_IF_NEEDED)
+                    .putExtra("shortcut_id", info.getId());
 
-                App app = Setup.appLoader().createApp(shortcutIntent);
-                Item item;
-                if (app != null) {
-                    item = Item.newAppItem(app);
-                } else {
-                    item = Item.newShortcutItem(shortcutIntent, shortcutIcon, shortcutLabel);
-                }
+                Context context = AppObject.get().getApplicationContext();
+                Drawable shortcutIcon = launcherApps.getShortcutIconDrawable(info, context.getResources().getDisplayMetrics().densityDpi);
+
+                Item item = Item.newShortcutItem(shortcutIntent, shortcutIcon, shortcutLabel);
                 Point preferredPos = HomeActivity.Companion.getLauncher().getDesktop().getPages().get(HomeActivity.Companion.getLauncher().getDesktop().getCurrentItem()).findFreeSpace();
+                
                 if (preferredPos == null) {
                     Tool.toast(HomeActivity.Companion.getLauncher(), R.string.toast_not_enough_space);
                 } else {

--- a/app/src/main/java/com/benny/openlauncher/activity/AddShortcutActivity.java
+++ b/app/src/main/java/com/benny/openlauncher/activity/AddShortcutActivity.java
@@ -1,0 +1,52 @@
+package com.benny.openlauncher.activity;
+
+import android.app.Activity;
+import android.content.Context;
+import android.content.pm.LauncherApps;
+import android.os.Build;
+import android.os.Bundle;
+
+public class AddItemActivity extends Activity {
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        if (getIntent() != null && getIntent().getAction().equalsIgnoreCase(LauncherApps.ACTION_CONFIRM_PIN_SHORTCUT)) {
+            LauncherApps launcherApps = (LauncherApps) getSystemService(Context.LAUNCHER_APPS_SERVICE);
+            LauncherApps.PinItemRequest request = launcherApps.getPinItemRequest(getIntent());
+            if (request == null) {
+                finish();
+                return;
+            }
+
+            if (request.getRequestType() == LauncherApps.PinItemRequest.REQUEST_TYPE_SHORTCUT) {
+                
+                ShortcutInfoCompat info = new ShortcutInfoCompat(request.getShortcutInfo());
+                String shortcutLabel = info.getShortLabel().toString();
+                Intent shortcutIntent = info.makeIntent();
+                Drawable shortcutIcon = null;
+
+                App app = Setup.appLoader().createApp(shortcutIntent);
+                Item item;
+                if (app != null) {
+                    item = Item.newAppItem(app);
+                } else {
+                    item = Item.newShortcutItem(shortcutIntent, shortcutIcon, shortcutLabel);
+                }
+                Point preferredPos = HomeActivity.Companion.getLauncher().getDesktop().getPages().get(HomeActivity.Companion.getLauncher().getDesktop().getCurrentItem()).findFreeSpace();
+                if (preferredPos == null) {
+                    Tool.toast(HomeActivity.Companion.getLauncher(), R.string.toast_not_enough_space);
+                } else {
+                    item.setX(preferredPos.x);
+                    item.setY(preferredPos.y);
+                    HomeActivity._db.saveItem(item, HomeActivity.Companion.getLauncher().getDesktop().getCurrentItem(), Definitions.ItemPosition.Desktop);
+                    HomeActivity.Companion.getLauncher().getDesktop().addItemToPage(item, HomeActivity.Companion.getLauncher().getDesktop().getCurrentItem());
+                    Log.d(this.getClass().toString(), "shortcut installed");
+                }
+
+                request.accept();
+                finish();
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/benny/openlauncher/widget/AppItemView.java
+++ b/app/src/main/java/com/benny/openlauncher/widget/AppItemView.java
@@ -1,11 +1,14 @@
 package com.benny.openlauncher.widget;
 
 import android.content.Context;
+import android.content.Intent;
+import android.content.pm.LauncherApps;
 import android.graphics.Canvas;
 import android.graphics.Color;
 import android.graphics.Paint;
 import android.graphics.Rect;
 import android.graphics.drawable.Drawable;
+import android.os.Process;
 import android.support.v4.content.ContextCompat;
 import android.util.AttributeSet;
 import android.view.View;
@@ -215,7 +218,20 @@ public class AppItemView extends View implements Drawable.Callback, Notification
                     Tool.createScaleInScaleOutAnim(_view, new Runnable() {
                         @Override
                         public void run() {
-                            _view.getContext().startActivity(item.getIntent());
+
+                            Intent intent = item.getIntent();
+                            String id = intent.getStringExtra("shortcut_id");
+
+                            /* old style shortcut */
+                            if (id == null || id.trim().isEmpty()) {
+                                _view.getContext().startActivity(intent);
+                            } 
+                            /* new style shortcut */
+                            else {
+                                LauncherApps launcherApps = (LauncherApps) _view.getContext().getSystemService(Context.LAUNCHER_APPS_SERVICE);
+                                String packageName = intent.getPackage();
+                                launcherApps.startShortcut(packageName, id, intent.getSourceBounds(), null, Process.myUserHandle());
+                            }
                         }
                     });
                 }

--- a/app/src/main/java/com/benny/openlauncher/widget/ItemOptionView.java
+++ b/app/src/main/java/com/benny/openlauncher/widget/ItemOptionView.java
@@ -343,12 +343,18 @@ public final class ItemOptionView extends FrameLayout {
         ArrayList<PopupIconLabelItem> itemList = new ArrayList<>();
         switch (getDragItem().getType()) {
             case APP:
-            case SHORTCUT:
                 if (!getDragAction().equals(Action.DRAWER)) {
                     itemList.add(editItem);
                     itemList.add(removeItem);
                 }
                 itemList.add(uninstallItem);
+                itemList.add(infoItem);
+                break;
+            case SHORTCUT:
+                if (!getDragAction().equals(Action.DRAWER)) {
+                    itemList.add(editItem);
+                    itemList.add(removeItem);
+                }
                 itemList.add(infoItem);
                 break;
             case ACTION:

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.3-bin.zip


### PR DESCRIPTION
I have worked on a solution to make PWAs installable from Firefox for Android as shown in the following pictures. The pictures have been made trying to install Mozilla`s test PWA (https://mdn.github.io/pwa-examples/a2hs/).

**Install button appears**

![Screenshot_20210104-120807_Firefox](https://user-images.githubusercontent.com/20972129/103530028-09638280-4e87-11eb-96ec-84c4f1293f5e.png)

**Shortcut with correct PWA icon and label created**

![Screenshot_20210104-120859_OpenLauncher](https://user-images.githubusercontent.com/20972129/103530082-1ed8ac80-4e87-11eb-8ac8-c23726697aee.png)

**PWA launched in full screen mode**

![Screenshot_20210104-120821_Firefox](https://user-images.githubusercontent.com/20972129/103530087-2009d980-4e87-11eb-874a-9cd4fefe1669.png)

Since I am not a Java nor an Android develeoper, this PR is not intended to be merged directly. Instead somebody with more knowledge should review and extend (or copy) it with necessary additions e.g. to handle different android versions. The shortcut feature is not only useful for PWAs but also for normal app shortcuts which I did not implement [example](https://www.google.com/url?sa=i&url=https%3A%2F%2Fwww.androidpolice.com%2F2018%2F01%2F14%2Fweekend-poll-use-app-shortcuts%2F&psig=AOvVaw3zuoJhWXt229bWFw5N6iw5&ust=1609845850616000&source=images&cd=vfe&ved=0CAMQjB1qFwoTCOiVrqKVgu4CFQAAAAAdAAAAABAE).

This is also related to #583 and #568.

My works are based on those of the Bliss Launcher of /e/-OS (https://gitlab.e.foundation/e/apps/BlissLauncher) which helped me to implement this feature.

- Note: I could not apply the "auto reformat feature" you mentioned because I do not have Android Studio installed.