### PR TITLE
Add app shortcuts on longpress

### DIFF
--- a/app/src/main/java/com/benny/openlauncher/activity/homeparts/HpItemOption.java
+++ b/app/src/main/java/com/benny/openlauncher/activity/homeparts/HpItemOption.java
@@ -1,10 +1,19 @@
 package com.benny.openlauncher.activity.homeparts;
 
+import static android.content.pm.LauncherApps.ShortcutQuery.FLAG_MATCH_DYNAMIC;
+import static android.content.pm.LauncherApps.ShortcutQuery.FLAG_MATCH_MANIFEST;
+import static android.content.pm.LauncherApps.ShortcutQuery.FLAG_MATCH_PINNED;
+
 import android.content.ComponentName;
+import android.content.Context;
 import android.content.Intent;
+import android.content.pm.LauncherApps;
+import android.content.pm.ShortcutInfo;
 import android.graphics.Point;
 import android.net.Uri;
+import android.os.Process;
 import android.support.annotation.NonNull;
+import android.util.Log;
 import android.view.View;
 
 import com.benny.openlauncher.R;
@@ -14,9 +23,12 @@ import com.benny.openlauncher.manager.Setup;
 import com.benny.openlauncher.model.Item;
 import com.benny.openlauncher.util.Definitions.ItemPosition;
 import com.benny.openlauncher.util.Tool;
+import com.benny.openlauncher.viewutil.PopupDynamicIconLabelItem;
 import com.benny.openlauncher.widget.Desktop;
 import com.benny.openlauncher.widget.Dock;
 import com.benny.openlauncher.widget.WidgetContainer;
+
+import java.util.List;
 
 public class HpItemOption implements DialogListener.OnEditDialogListener {
     private HomeActivity _homeActivity;
@@ -81,6 +93,14 @@ public class HpItemOption implements DialogListener.OnEditDialogListener {
 
         if (coordinateToChildView != null) {
             ((WidgetContainer) coordinateToChildView).showResize();
+        }
+    }
+
+    public final void onStartShortcutItem(@NonNull Item item, int position) {
+        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.N_MR1) {
+            LauncherApps launcherApps = (LauncherApps) _homeActivity.getSystemService(Context.LAUNCHER_APPS_SERVICE);
+            ShortcutInfo shortcutInfo = item.getShortcutInfo().get(position);
+            launcherApps.startShortcut(shortcutInfo, null, null);
         }
     }
 

--- a/app/src/main/java/com/benny/openlauncher/model/App.java
+++ b/app/src/main/java/com/benny/openlauncher/model/App.java
@@ -2,13 +2,14 @@ package com.benny.openlauncher.model;
 
 import android.annotation.SuppressLint;
 import android.content.ComponentName;
-import android.content.Intent;
-import android.content.pm.ApplicationInfo;
 import android.content.pm.LauncherActivityInfo;
 import android.content.pm.PackageManager;
 import android.content.pm.ResolveInfo;
+import android.content.pm.ShortcutInfo;
 import android.graphics.drawable.Drawable;
 import android.os.UserHandle;
+
+import java.util.List;
 
 public class App {
     public Drawable _icon;
@@ -16,20 +17,23 @@ public class App {
     public String _packageName;
     public String _className;
     public UserHandle _userHandle;
+    public List<ShortcutInfo> _shortcutInfo;
 
-    public App(PackageManager pm, ResolveInfo info) {
+    public App(PackageManager pm, ResolveInfo info, List<ShortcutInfo> shortcutInfo) {
         _icon = info.loadIcon(pm);
         _label = info.loadLabel(pm).toString();
         _packageName = info.activityInfo.packageName;
         _className = info.activityInfo.name;
+        _shortcutInfo = shortcutInfo;
     }
 
     @SuppressLint("NewApi")
-    public App(PackageManager pm, LauncherActivityInfo info) {
+    public App(PackageManager pm, LauncherActivityInfo info, List<ShortcutInfo> shortcutInfo) {
         _icon = info.getIcon(0);
         _label = info.getLabel().toString();
         _packageName = info.getComponentName().getPackageName();
         _className = info.getName();
+        _shortcutInfo = shortcutInfo;
     }
 
     @Override
@@ -64,5 +68,9 @@ public class App {
 
     public String getComponentName() {
         return new ComponentName(_packageName, _className).toString();
+    }
+
+    public List<ShortcutInfo> getShortcutInfo() {
+        return _shortcutInfo;
     }
 }

--- a/app/src/main/java/com/benny/openlauncher/model/Item.java
+++ b/app/src/main/java/com/benny/openlauncher/model/Item.java
@@ -2,6 +2,7 @@ package com.benny.openlauncher.model;
 
 import android.content.ComponentName;
 import android.content.Intent;
+import android.content.pm.ShortcutInfo;
 import android.graphics.drawable.Drawable;
 
 import com.benny.openlauncher.util.Definitions;
@@ -24,6 +25,9 @@ public class Item {
 
     // intent for shortcuts and apps
     public Intent _intent;
+
+    // list of shortcutInfo for shortcuts
+    public List<ShortcutInfo> _shortcutInfo;
 
     // list of items for groups
     public List<Item> _items;
@@ -48,6 +52,7 @@ public class Item {
         item._label = app.getLabel();
         item._icon = app.getIcon();
         item._intent = Tool.getIntentFromApp(app);
+        item._shortcutInfo = app.getShortcutInfo();
         return item;
     }
 
@@ -128,6 +133,10 @@ public class Item {
 
     public Type getType() {
         return _type;
+    }
+
+    public List<ShortcutInfo> getShortcutInfo() {
+        return _shortcutInfo;
     }
 
     public List<Item> getGroupItems() {

--- a/app/src/main/java/com/benny/openlauncher/model/Item.java
+++ b/app/src/main/java/com/benny/openlauncher/model/Item.java
@@ -139,6 +139,10 @@ public class Item {
         return _shortcutInfo;
     }
 
+    public void setShortcutInfo(List<ShortcutInfo> shortcutInfo) {
+        _shortcutInfo = shortcutInfo;
+    }
+
     public List<Item> getGroupItems() {
         return _items;
     }

--- a/app/src/main/java/com/benny/openlauncher/util/AppManager.java
+++ b/app/src/main/java/com/benny/openlauncher/util/AppManager.java
@@ -1,9 +1,5 @@
 package com.benny.openlauncher.util;
 
-import static android.content.pm.LauncherApps.ShortcutQuery.FLAG_MATCH_DYNAMIC;
-import static android.content.pm.LauncherApps.ShortcutQuery.FLAG_MATCH_MANIFEST;
-import static android.content.pm.LauncherApps.ShortcutQuery.FLAG_MATCH_PINNED;
-
 import android.content.Context;
 import android.content.Intent;
 import android.content.pm.LauncherActivityInfo;
@@ -13,7 +9,6 @@ import android.content.pm.ResolveInfo;
 import android.content.pm.ShortcutInfo;
 import android.os.AsyncTask;
 import android.os.Build;
-import android.os.Process;
 import android.os.UserHandle;
 import android.support.annotation.NonNull;
 
@@ -109,19 +104,7 @@ public class AppManager {
     public App createApp(Intent intent) {
         try {
             ResolveInfo info = _packageManager.resolveActivity(intent, 0);
-            List<ShortcutInfo> shortcutInfo = null;
-            if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.N_MR1) {
-                String packageName = intent.getComponent().getPackageName();
-                LauncherApps launcherApps = (LauncherApps) getContext().getSystemService(Context.LAUNCHER_APPS_SERVICE);
-                LauncherApps.ShortcutQuery shortcutQuery = new LauncherApps.ShortcutQuery();
-                shortcutQuery.setQueryFlags(FLAG_MATCH_DYNAMIC | FLAG_MATCH_MANIFEST | FLAG_MATCH_PINNED);
-                shortcutQuery.setPackage(packageName);
-                try {
-                    shortcutInfo = launcherApps.getShortcuts(shortcutQuery, Process.myUserHandle());
-                } catch (SecurityException e) {
-                    LOG.warn("Can't get shortcuts info. App is not set as default launcher");
-                }
-            }
+            List<ShortcutInfo> shortcutInfo = Tool.getShortcutInfo(getContext(), intent.getComponent().getPackageName());
             return new App(_packageManager, info, shortcutInfo);
         } catch (Exception e) {
             e.printStackTrace();
@@ -187,15 +170,7 @@ public class AppManager {
                 for (UserHandle userHandle : profiles) {
                     List<LauncherActivityInfo> apps = launcherApps.getActivityList(null, userHandle);
                     for (LauncherActivityInfo info : apps) {
-                        LauncherApps.ShortcutQuery shortcutQuery = new LauncherApps.ShortcutQuery();
-                        shortcutQuery.setQueryFlags(FLAG_MATCH_DYNAMIC | FLAG_MATCH_MANIFEST | FLAG_MATCH_PINNED);
-                        shortcutQuery.setPackage(info.getComponentName().getPackageName());
-                        List<ShortcutInfo> shortcutInfo = null;
-                        try {
-                            shortcutInfo = launcherApps.getShortcuts(shortcutQuery, userHandle);
-                        } catch (SecurityException e) {
-                            LOG.warn("Can't get shortcuts info. App is not set as default launcher");
-                        }
+                        List<ShortcutInfo> shortcutInfo = Tool.getShortcutInfo(getContext(), info.getComponentName().getPackageName());
                         App app = new App(_packageManager, info, shortcutInfo);
                         app._userHandle = userHandle;
                         LOG.debug("adding work profile to non filtered list: {}, {}, {}", app._label, app._packageName, app._className);
@@ -207,20 +182,7 @@ public class AppManager {
                 intent.addCategory(Intent.CATEGORY_LAUNCHER);
                 List<ResolveInfo> activitiesInfo = _packageManager.queryIntentActivities(intent, 0);
                 for (ResolveInfo info : activitiesInfo) {
-                    List<ShortcutInfo> shortcutInfo = null;
-                    if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.N_MR1) {
-                        String packageName = intent.getComponent().getPackageName();
-                        LauncherApps launcherApps = (LauncherApps) getContext().getSystemService(Context.LAUNCHER_APPS_SERVICE);
-                        LauncherApps.ShortcutQuery shortcutQuery = new LauncherApps.ShortcutQuery();
-                        shortcutQuery.setQueryFlags(FLAG_MATCH_DYNAMIC | FLAG_MATCH_MANIFEST | FLAG_MATCH_PINNED);
-                        shortcutQuery.setPackage(packageName);
-                        try {
-                            shortcutInfo = launcherApps.getShortcuts(shortcutQuery, Process.myUserHandle());
-                        } catch (SecurityException e) {
-                            LOG.warn("Can't get shortcuts info. App is not set as default launcher");
-                        }
-                    }
-
+                    List<ShortcutInfo> shortcutInfo = Tool.getShortcutInfo(getContext(), intent.getComponent().getPackageName());
                     App app = new App(_packageManager, info, shortcutInfo);
                     LOG.debug("adding app to non filtered list: {}, {}, {}", app._label,  app._packageName, app._className);
                     nonFilteredAppsTemp.add(app);

--- a/app/src/main/java/com/benny/openlauncher/util/AppManager.java
+++ b/app/src/main/java/com/benny/openlauncher/util/AppManager.java
@@ -1,13 +1,19 @@
 package com.benny.openlauncher.util;
 
+import static android.content.pm.LauncherApps.ShortcutQuery.FLAG_MATCH_DYNAMIC;
+import static android.content.pm.LauncherApps.ShortcutQuery.FLAG_MATCH_MANIFEST;
+import static android.content.pm.LauncherApps.ShortcutQuery.FLAG_MATCH_PINNED;
+
 import android.content.Context;
 import android.content.Intent;
 import android.content.pm.LauncherActivityInfo;
 import android.content.pm.LauncherApps;
 import android.content.pm.PackageManager;
 import android.content.pm.ResolveInfo;
+import android.content.pm.ShortcutInfo;
 import android.os.AsyncTask;
 import android.os.Build;
+import android.os.Process;
 import android.os.UserHandle;
 import android.support.annotation.NonNull;
 
@@ -103,7 +109,20 @@ public class AppManager {
     public App createApp(Intent intent) {
         try {
             ResolveInfo info = _packageManager.resolveActivity(intent, 0);
-            return new App(_packageManager, info);
+            List<ShortcutInfo> shortcutInfo = null;
+            if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.N_MR1) {
+                String packageName = intent.getComponent().getPackageName();
+                LauncherApps launcherApps = (LauncherApps) getContext().getSystemService(Context.LAUNCHER_APPS_SERVICE);
+                LauncherApps.ShortcutQuery shortcutQuery = new LauncherApps.ShortcutQuery();
+                shortcutQuery.setQueryFlags(FLAG_MATCH_DYNAMIC | FLAG_MATCH_MANIFEST | FLAG_MATCH_PINNED);
+                shortcutQuery.setPackage(packageName);
+                try {
+                    shortcutInfo = launcherApps.getShortcuts(shortcutQuery, Process.myUserHandle());
+                } catch (SecurityException e) {
+                    LOG.warn("Can't get shortcuts info. App is not set as default launcher");
+                }
+            }
+            return new App(_packageManager, info, shortcutInfo);
         } catch (Exception e) {
             e.printStackTrace();
             return null;
@@ -168,9 +187,17 @@ public class AppManager {
                 for (UserHandle userHandle : profiles) {
                     List<LauncherActivityInfo> apps = launcherApps.getActivityList(null, userHandle);
                     for (LauncherActivityInfo info : apps) {
-                        App app = new App(_packageManager, info);
+                        LauncherApps.ShortcutQuery shortcutQuery = new LauncherApps.ShortcutQuery();
+                        shortcutQuery.setQueryFlags(FLAG_MATCH_DYNAMIC | FLAG_MATCH_MANIFEST | FLAG_MATCH_PINNED);
+                        shortcutQuery.setPackage(info.getComponentName().getPackageName());
+                        List<ShortcutInfo> shortcutInfo = null;
+                        try {
+                            shortcutInfo = launcherApps.getShortcuts(shortcutQuery, userHandle);
+                        } catch (SecurityException e) {
+                            LOG.warn("Can't get shortcuts info. App is not set as default launcher");
+                        }
+                        App app = new App(_packageManager, info, shortcutInfo);
                         app._userHandle = userHandle;
-
                         LOG.debug("adding work profile to non filtered list: {}, {}, {}", app._label, app._packageName, app._className);
                         nonFilteredAppsTemp.add(app);
                     }
@@ -180,8 +207,21 @@ public class AppManager {
                 intent.addCategory(Intent.CATEGORY_LAUNCHER);
                 List<ResolveInfo> activitiesInfo = _packageManager.queryIntentActivities(intent, 0);
                 for (ResolveInfo info : activitiesInfo) {
-                    App app = new App(_packageManager, info);
+                    List<ShortcutInfo> shortcutInfo = null;
+                    if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.N_MR1) {
+                        String packageName = intent.getComponent().getPackageName();
+                        LauncherApps launcherApps = (LauncherApps) getContext().getSystemService(Context.LAUNCHER_APPS_SERVICE);
+                        LauncherApps.ShortcutQuery shortcutQuery = new LauncherApps.ShortcutQuery();
+                        shortcutQuery.setQueryFlags(FLAG_MATCH_DYNAMIC | FLAG_MATCH_MANIFEST | FLAG_MATCH_PINNED);
+                        shortcutQuery.setPackage(packageName);
+                        try {
+                            shortcutInfo = launcherApps.getShortcuts(shortcutQuery, Process.myUserHandle());
+                        } catch (SecurityException e) {
+                            LOG.warn("Can't get shortcuts info. App is not set as default launcher");
+                        }
+                    }
 
+                    App app = new App(_packageManager, info, shortcutInfo);
                     LOG.debug("adding app to non filtered list: {}, {}, {}", app._label,  app._packageName, app._className);
                     nonFilteredAppsTemp.add(app);
                 }

--- a/app/src/main/java/com/benny/openlauncher/util/DatabaseHelper.java
+++ b/app/src/main/java/com/benny/openlauncher/util/DatabaseHelper.java
@@ -267,13 +267,20 @@ public class DatabaseHelper extends SQLiteOpenHelper {
 
         String[] dataSplit;
         switch (type) {
-            case APP:
-            case SHORTCUT:
+            case APP: {
+                item.setIntent(Tool.getIntentFromString(data));
+                item.setShortcutInfo(Tool.getShortcutInfo(_context, item.getIntent().getComponent().getPackageName()));
+                App app = Setup.get().getAppLoader().findItemApp(item);
+                item.setIcon(app != null ? app.getIcon() : null);
+                break;
+            }
+            case SHORTCUT: {
                 item.setIntent(Tool.getIntentFromString(data));
                 App app = Setup.get().getAppLoader().findItemApp(item);
                 item.setIcon(app != null ? app.getIcon() : null);
                 break;
-            case GROUP:
+            }
+            case GROUP: {
                 item.setItems(new ArrayList<>());
                 dataSplit = data.split(Definitions.DELIMITER);
                 for (String string : dataSplit) {
@@ -284,15 +291,18 @@ public class DatabaseHelper extends SQLiteOpenHelper {
                     }
                 }
                 break;
-            case ACTION:
+            }
+            case ACTION: {
                 item.setActionValue(Integer.parseInt(data));
                 break;
-            case WIDGET:
+            }
+            case WIDGET: {
                 dataSplit = data.split(Definitions.DELIMITER);
                 item.setWidgetValue(Integer.parseInt(dataSplit[0]));
                 item.setSpanX(Integer.parseInt(dataSplit[1]));
                 item.setSpanY(Integer.parseInt(dataSplit[2]));
                 break;
+            }
         }
 
         return item;

--- a/app/src/main/java/com/benny/openlauncher/util/DragHandler.java
+++ b/app/src/main/java/com/benny/openlauncher/util/DragHandler.java
@@ -29,6 +29,13 @@ public final class DragHandler {
             @Override
             public boolean onLongClick(View view) {
                 if (Setup.appSettings().getDesktopLock()) {
+                    if (HomeActivity.Companion.getLauncher() != null && !DragAction.Action.SEARCH.equals(action)) {
+                        if (Setup.appSettings().getGestureFeedback()) {
+                            Tool.vibrate(view);
+                        }
+                        HomeActivity._launcher.getItemOptionView().showItemPopupForLockedDesktop(item, HomeActivity.Companion.getLauncher());
+                        return true;
+                    }
                     return false;
                 }
                 if (Setup.appSettings().getGestureFeedback()) {

--- a/app/src/main/java/com/benny/openlauncher/util/Tool.java
+++ b/app/src/main/java/com/benny/openlauncher/util/Tool.java
@@ -1,8 +1,14 @@
 package com.benny.openlauncher.util;
 
+import static android.content.pm.LauncherApps.ShortcutQuery.FLAG_MATCH_DYNAMIC;
+import static android.content.pm.LauncherApps.ShortcutQuery.FLAG_MATCH_MANIFEST;
+import static android.content.pm.LauncherApps.ShortcutQuery.FLAG_MATCH_PINNED;
+
 import android.content.Context;
 import android.content.Intent;
+import android.content.pm.LauncherApps;
 import android.content.pm.PackageManager;
+import android.content.pm.ShortcutInfo;
 import android.content.res.Resources;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
@@ -12,9 +18,12 @@ import android.graphics.drawable.BitmapDrawable;
 import android.graphics.drawable.Drawable;
 import android.os.Build;
 import android.os.Handler;
+import android.os.Process;
 import android.os.VibrationEffect;
 import android.os.Vibrator;
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.util.Log;
 import android.view.HapticFeedbackConstants;
 import android.view.View;
 import android.view.ViewPropertyAnimator;
@@ -252,5 +261,22 @@ public class Tool {
                 e.printStackTrace();
             }
         }
+    }
+
+    @Nullable
+    public static List<ShortcutInfo> getShortcutInfo(@NonNull Context context, @NonNull String packageName) {
+        List<ShortcutInfo> shortcutInfo = null;
+        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.N_MR1) {
+            LauncherApps launcherApps = (LauncherApps) context.getSystemService(Context.LAUNCHER_APPS_SERVICE);
+            LauncherApps.ShortcutQuery shortcutQuery = new LauncherApps.ShortcutQuery();
+            shortcutQuery.setQueryFlags(FLAG_MATCH_DYNAMIC | FLAG_MATCH_MANIFEST | FLAG_MATCH_PINNED);
+            shortcutQuery.setPackage(packageName);
+            try {
+                shortcutInfo = launcherApps.getShortcuts(shortcutQuery, Process.myUserHandle());
+            } catch (SecurityException e) {
+                Log.w(Tool.class.getSimpleName(), "Can't get shortcuts info. App is not set as default launcher");
+            }
+        }
+        return shortcutInfo;
     }
 }

--- a/app/src/main/java/com/benny/openlauncher/viewutil/AbstractPopupIconLabelItem.java
+++ b/app/src/main/java/com/benny/openlauncher/viewutil/AbstractPopupIconLabelItem.java
@@ -1,0 +1,27 @@
+package com.benny.openlauncher.viewutil;
+
+import android.support.v7.widget.RecyclerView;
+import android.view.View;
+import android.widget.ImageView;
+import android.widget.TextView;
+
+import com.benny.openlauncher.R;
+import com.mikepenz.fastadapter.IClickable;
+import com.mikepenz.fastadapter.IItem;
+import com.mikepenz.fastadapter.items.AbstractItem;
+
+public abstract class AbstractPopupIconLabelItem<Item extends IItem & IClickable> extends AbstractItem<Item, AbstractPopupIconLabelItem.ViewHolder> {
+
+    static class ViewHolder extends RecyclerView.ViewHolder {
+        ImageView iconView;
+        TextView labelView;
+
+        ViewHolder(View itemView) {
+            super(itemView);
+
+            labelView = itemView.findViewById(R.id.item_popup_label);
+            iconView = itemView.findViewById(R.id.item_popup_icon);
+        }
+    }
+
+}

--- a/app/src/main/java/com/benny/openlauncher/viewutil/PopupDynamicIconLabelItem.java
+++ b/app/src/main/java/com/benny/openlauncher/viewutil/PopupDynamicIconLabelItem.java
@@ -1,5 +1,6 @@
 package com.benny.openlauncher.viewutil;
 
+import android.graphics.drawable.Drawable;
 import android.support.annotation.NonNull;
 import android.view.View;
 import android.widget.ImageView;
@@ -9,13 +10,13 @@ import com.benny.openlauncher.R;
 
 import java.util.List;
 
-public final class PopupIconLabelItem extends AbstractPopupIconLabelItem<PopupIconLabelItem> {
-    private final int _iconRes;
-    private final int _labelRes;
+public final class PopupDynamicIconLabelItem extends AbstractPopupIconLabelItem<PopupDynamicIconLabelItem> {
+    private final Drawable _icon;
+    private final CharSequence _label;
 
-    public PopupIconLabelItem(int labelRes, int iconRes) {
-        _labelRes = labelRes;
-        _iconRes = iconRes;
+    public PopupDynamicIconLabelItem(CharSequence label, Drawable icon) {
+        _label = label;
+        _icon = icon;
     }
 
     public int getType() {
@@ -31,11 +32,11 @@ public final class PopupIconLabelItem extends AbstractPopupIconLabelItem<PopupIc
 
         TextView labelView = holder.labelView;
         if (labelView != null) {
-            labelView.setText(_labelRes);
+            labelView.setText(_label);
         }
 
         ImageView iconView = holder.iconView;
-        iconView.setImageResource(_iconRes);
+        iconView.setImageDrawable(_icon);
     }
 
     public void unbindView(@NonNull ViewHolder holder) {
@@ -48,6 +49,7 @@ public final class PopupIconLabelItem extends AbstractPopupIconLabelItem<PopupIc
         iconView.setImageDrawable(null);
     }
 
+    @NonNull
     @Override
     public ViewHolder getViewHolder(@NonNull View view) {
         return new ViewHolder(view);

--- a/app/src/main/java/com/benny/openlauncher/widget/GroupPopupView.java
+++ b/app/src/main/java/com/benny/openlauncher/widget/GroupPopupView.java
@@ -129,19 +129,25 @@ public class GroupPopupView extends RevealFrameLayout {
                     view.setOnLongClickListener(new OnLongClickListener() {
                         @Override
                         public boolean onLongClick(View view2) {
-                            if (Setup.appSettings().getDesktopLock()) return false;
+                            if (Setup.appSettings().getDesktopLock()) {
+                                if (HomeActivity.Companion.getLauncher() != null) {
+                                    HomeActivity._launcher.getItemOptionView().showItemPopupForLockedDesktop(groupItem, HomeActivity.Companion.getLauncher());
+                                    return true;
+                                }
+                                return false;
+                            } else {
+                                removeItem(context, item, groupItem, (AppItemView) itemView);
 
-                            removeItem(context, item, groupItem, (AppItemView) itemView);
+                                // start the drag action
+                                DragHandler.startDrag(view, groupItem, DragAction.Action.DESKTOP, null);
 
-                            // start the drag action
-                            DragHandler.startDrag(view, groupItem, DragAction.Action.DESKTOP, null);
+                                collapse();
 
-                            collapse();
-
-                            // update group icon or
-                            // convert group item into app item if there is only one item left
-                            updateItem(callback, item, itemView);
-                            return true;
+                                // update group icon or
+                                // convert group item into app item if there is only one item left
+                                updateItem(callback, item, itemView);
+                                return true;
+                            }
                         }
                     });
                     view.setOnClickListener(new OnClickListener() {

--- a/app/src/main/java/com/benny/openlauncher/widget/ItemOptionView.java
+++ b/app/src/main/java/com/benny/openlauncher/widget/ItemOptionView.java
@@ -7,6 +7,7 @@ import android.content.pm.ShortcutInfo;
 import android.graphics.Canvas;
 import android.graphics.Paint;
 import android.graphics.PointF;
+import android.os.Build;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.v7.widget.LinearLayoutManager;
@@ -425,6 +426,55 @@ public final class ItemOptionView extends FrameLayout {
                 collapse();
                 return true;
             }
+        });
+    }
+
+    public void showItemPopupForLockedDesktop(Item item, final HomeActivity homeActivity) {
+        ArrayList<AbstractPopupIconLabelItem> itemList = new ArrayList<>();
+        switch (item.getType()) {
+            case APP:
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N_MR1 && item.getShortcutInfo() != null) {
+                    for (ShortcutInfo shortcutInfo : item.getShortcutInfo()) {
+                        itemList.add(getAppShortcutItem(shortcutInfo));
+                    }
+                }
+            case SHORTCUT:
+                itemList.add(uninstallItem);
+                itemList.add(infoItem);
+                break;
+        }
+
+        float x = getDragLocation().x - HomeActivity._itemTouchX + Tool.dp2px(10);
+        float y = getDragLocation().y - HomeActivity._itemTouchY - Tool.dp2px((46 * itemList.size()));
+
+        if ((x + Tool.dp2px(200)) > getWidth()) {
+            setPopupMenuShowDirection(false);
+            x = getDragLocation().x - HomeActivity._itemTouchX + homeActivity.getDesktop().getCurrentPage().getCellWidth() - Tool.dp2px(200) - Tool.dp2px(10);
+        } else {
+            setPopupMenuShowDirection(true);
+        }
+
+        if (y < 0) {
+            y = getDragLocation().y - HomeActivity._itemTouchY + homeActivity.getDesktop().getCurrentPage().getCellHeight() + Tool.dp2px(4);
+        } else {
+            y -= Tool.dp2px(4);
+        }
+
+        showPopupMenuForItem(x, y, itemList, (v, adapter, item1, position) -> {
+            HpItemOption itemOption = new HpItemOption(homeActivity);
+            switch ((int) item1.getIdentifier()) {
+                case uninstallItemIdentifier:
+                    itemOption.onUninstallItem(item);
+                    break;
+                case infoItemIdentifier:
+                    itemOption.onInfoItem(item);
+                    break;
+                case startShortcutItemIdentifier:
+                    itemOption.onStartShortcutItem(item, position);
+                    break;
+            }
+            collapse();
+            return true;
         });
     }
 

--- a/app/src/main/java/com/benny/openlauncher/widget/ItemOptionView.java
+++ b/app/src/main/java/com/benny/openlauncher/widget/ItemOptionView.java
@@ -2,6 +2,8 @@ package com.benny.openlauncher.widget;
 
 import android.annotation.SuppressLint;
 import android.content.Context;
+import android.content.pm.LauncherApps;
+import android.content.pm.ShortcutInfo;
 import android.graphics.Canvas;
 import android.graphics.Paint;
 import android.graphics.PointF;
@@ -24,6 +26,8 @@ import com.benny.openlauncher.model.Item;
 import com.benny.openlauncher.util.DragAction.Action;
 import com.benny.openlauncher.util.DragHandler;
 import com.benny.openlauncher.util.Tool;
+import com.benny.openlauncher.viewutil.AbstractPopupIconLabelItem;
+import com.benny.openlauncher.viewutil.PopupDynamicIconLabelItem;
 import com.benny.openlauncher.viewutil.PopupIconLabelItem;
 import com.mikepenz.fastadapter.IAdapter;
 import com.mikepenz.fastadapter.commons.adapters.FastItemAdapter;
@@ -53,7 +57,7 @@ public final class ItemOptionView extends FrameLayout {
     private float _folderPreviewScale;
     private float _overlayIconScale;
     private final RecyclerView _overlayPopup;
-    private final FastItemAdapter<PopupIconLabelItem> _overlayPopupAdapter;
+    private final FastItemAdapter<AbstractPopupIconLabelItem> _overlayPopupAdapter;
     private boolean _overlayPopupShowing;
     private final OverlayView _overlayView;
     private final Paint _paint;
@@ -69,12 +73,14 @@ public final class ItemOptionView extends FrameLayout {
     private final int editItemIdentifier = 85;
     private final int removeItemIdentifier = 86;
     private final int resizeItemIdentifier = 87;
+    private final int startShortcutItemIdentifier = 88;
 
     private PopupIconLabelItem uninstallItem = new PopupIconLabelItem(R.string.uninstall, R.drawable.ic_delete).withIdentifier(uninstallItemIdentifier);
     private PopupIconLabelItem infoItem = new PopupIconLabelItem(R.string.info, R.drawable.ic_info).withIdentifier(infoItemIdentifier);
     private PopupIconLabelItem editItem = new PopupIconLabelItem(R.string.edit, R.drawable.ic_edit).withIdentifier(editItemIdentifier);
     private PopupIconLabelItem removeItem = new PopupIconLabelItem(R.string.remove, R.drawable.ic_close).withIdentifier(removeItemIdentifier);
     private PopupIconLabelItem resizeItem = new PopupIconLabelItem(R.string.resize, R.drawable.ic_resize).withIdentifier(resizeItemIdentifier);
+
 
     public static final class DragFlag {
         private boolean _previousOutside = true;
@@ -225,7 +231,7 @@ public final class ItemOptionView extends FrameLayout {
         _overlayPopup.bringToFront();
     }
 
-    public final void showPopupMenuForItem(float x, float y, @NonNull List<PopupIconLabelItem> popupItem, com.mikepenz.fastadapter.listeners.OnClickListener<PopupIconLabelItem> listener) {
+    public final void showPopupMenuForItem(float x, float y, @NonNull List<AbstractPopupIconLabelItem> popupItem, com.mikepenz.fastadapter.listeners.OnClickListener<AbstractPopupIconLabelItem> listener) {
         if (!_overlayPopupShowing) {
             _overlayPopupShowing = true;
             _overlayPopup.setVisibility(View.VISIBLE);
@@ -340,9 +346,14 @@ public final class ItemOptionView extends FrameLayout {
     }
 
     public void showItemPopup(final HomeActivity homeActivity) {
-        ArrayList<PopupIconLabelItem> itemList = new ArrayList<>();
+        ArrayList<AbstractPopupIconLabelItem> itemList = new ArrayList<>();
         switch (getDragItem().getType()) {
             case APP:
+                if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.N_MR1 && getDragItem().getShortcutInfo() != null) {
+                    for (ShortcutInfo shortcutInfo : getDragItem().getShortcutInfo()) {
+                        itemList.add(getAppShortcutItem(shortcutInfo));
+                    }
+                }
                 if (!getDragAction().equals(Action.DRAWER)) {
                     itemList.add(editItem);
                     itemList.add(removeItem);
@@ -384,9 +395,9 @@ public final class ItemOptionView extends FrameLayout {
             y -= Tool.dp2px(4);
         }
 
-        showPopupMenuForItem(x, y, itemList, new com.mikepenz.fastadapter.listeners.OnClickListener<PopupIconLabelItem>() {
+        showPopupMenuForItem(x, y, itemList, new com.mikepenz.fastadapter.listeners.OnClickListener<AbstractPopupIconLabelItem>() {
             @Override
-            public boolean onClick(View v, IAdapter<PopupIconLabelItem> adapter, PopupIconLabelItem item, int position) {
+            public boolean onClick(View v, IAdapter<AbstractPopupIconLabelItem> adapter, AbstractPopupIconLabelItem item, int position) {
                 Item dragItem = getDragItem();
                 if (dragItem != null) {
                     HpItemOption itemOption = new HpItemOption(homeActivity);
@@ -406,12 +417,24 @@ public final class ItemOptionView extends FrameLayout {
                         case resizeItemIdentifier:
                             itemOption.onResizeItem(dragItem);
                             break;
+                        case startShortcutItemIdentifier:
+                            itemOption.onStartShortcutItem(dragItem, position);
+                            break;
                     }
                 }
                 collapse();
                 return true;
             }
         });
+    }
+
+    private PopupDynamicIconLabelItem getAppShortcutItem(@NonNull ShortcutInfo shortcutInfo) {
+        PopupDynamicIconLabelItem popupDynamicIconLabelItem = null;
+        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.N_MR1) {
+            LauncherApps launcherApps = (LauncherApps) getContext().getSystemService(Context.LAUNCHER_APPS_SERVICE);
+            popupDynamicIconLabelItem = new PopupDynamicIconLabelItem(shortcutInfo.getShortLabel(), launcherApps.getShortcutIconDrawable(shortcutInfo, getContext().getResources().getDisplayMetrics().densityDpi)).withIdentifier(startShortcutItemIdentifier);
+        }
+        return popupDynamicIconLabelItem;
     }
 
     private final void handleMovement() {


### PR DESCRIPTION
Add app shortcuts (#648) in Home screen and All apps screen (API 25+).

- List<ShortcutInfo> _shortcutInfo field was added to App and Item classes
- PopupDynamicIconLabelItem class was added to handle text and icon specific for each app
- AbstractPopupIconLabelItem abstract class was added as a parent to PopupIconLabelItem and PopupDynamicIconLabelItem

Known issue/android bug:
Launcher can't get app shortcuts until set as a default launcher.

Before:
![Screenshot_1633186974](https://user-images.githubusercontent.com/14164722/135722812-1c545ffc-0926-45f3-814b-7421919841f7.png)
After:
![Screenshot_1633187035](https://user-images.githubusercontent.com/14164722/135722813-710372ce-2411-4013-a8ca-80da70b5c756.png)
![Screenshot_1633187057](https://user-images.githubusercontent.com/14164722/135722814-86dc6f86-38ac-444d-ac57-06f0d27be5cd.png)
. 