### PR TITLE
fix overlapping similar apps when grouping bug by updating the deskto…

### DIFF
--- a/app/src/main/java/com/benny/openlauncher/activity/homeparts/HpDragOption.java
+++ b/app/src/main/java/com/benny/openlauncher/activity/homeparts/HpDragOption.java
@@ -188,6 +188,7 @@ public class HpDragOption {
                     _homeActivity.getDock().consumeLastItem();
                     // add the item to the database
                     HomeActivity._db.saveItem(item, _homeActivity.getDesktop().getCurrentItem(), Definitions.ItemPosition.Desktop);
+                    _homeActivity.getDesktop().initDesktop();
                 } else {
                     Point pos = new Point();
                     _homeActivity.getDesktop().getCurrentPage().touchPosToCoordinate(pos, x, y, item._spanX, item._spanY, false);


### PR DESCRIPTION
When two similar apps are copied from the drawer to the desktop. After updating the page and exiting and re-entering the launcher, it is seen that a group has been created and an icon has been placed on it.
This bug has been fixed in this Request 

![ezgif](https://user-images.githubusercontent.com/16717834/161065076-2441fa74-26ee-4604-9202-72644233e495.gif)
