### PR TITLE
Add ZIP extension filter to restore backup

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -88,6 +88,15 @@
             </intent-filter>
         </activity>
         <activity
+        android:name="com.benny.openlauncher.activity.ZipFilePickerActivity"
+        android:label="@string/app_name"
+        android:theme="@style/FilePickerTheme">
+        <intent-filter>
+            <action android:name="android.intent.action.GET_CONTENT" />
+            <category android:name="android.intent.category.DEFAULT" />
+        </intent-filter>
+        </activity>
+        <activity
             android:name="com.benny.openlauncher.activity.AddShortcutActivity"
             android:autoRemoveFromRecents="true"
             android:excludeFromRecents="true"

--- a/app/src/main/java/com/benny/openlauncher/activity/ZipFilePickerActivity.java
+++ b/app/src/main/java/com/benny/openlauncher/activity/ZipFilePickerActivity.java
@@ -1,0 +1,30 @@
+package com.benny.openlauncher.activity;
+
+import android.annotation.SuppressLint;
+import android.os.Environment;
+import android.support.annotation.Nullable;
+
+import com.benny.openlauncher.fragment.ZipFilePickerFragment;
+import com.nononsenseapps.filepicker.AbstractFilePickerActivity;
+import com.nononsenseapps.filepicker.AbstractFilePickerFragment;
+
+import java.io.File;
+
+@SuppressLint("Registered")
+public class ZipFilePickerActivity extends AbstractFilePickerActivity<File> {
+    public ZipFilePickerActivity() {
+        super();
+    }
+
+    @Override
+    public AbstractFilePickerFragment<File> getFragment(
+            @Nullable final String startPath, final int mode, final boolean allowMultiple,
+            final boolean allowCreateDir, final boolean allowExistingFile,
+            final boolean singleClick) {
+        AbstractFilePickerFragment<File> fragment = new ZipFilePickerFragment();
+        // startPath is allowed to be null. In that case, default folder should be SD-card and not "/"
+        fragment.setArgs(startPath != null ? startPath : Environment.getExternalStorageDirectory().getPath(),
+                mode, allowMultiple, allowCreateDir, allowExistingFile, singleClick);
+        return fragment;
+    }
+}

--- a/app/src/main/java/com/benny/openlauncher/fragment/SettingsMiscellaneousFragment.java
+++ b/app/src/main/java/com/benny/openlauncher/fragment/SettingsMiscellaneousFragment.java
@@ -11,6 +11,7 @@ import com.afollestad.materialdialogs.DialogAction;
 import com.afollestad.materialdialogs.MaterialDialog;
 import com.benny.openlauncher.R;
 import com.benny.openlauncher.activity.HomeActivity;
+import com.benny.openlauncher.activity.ZipFilePickerActivity;
 import com.benny.openlauncher.util.AppSettings;
 import com.benny.openlauncher.util.DatabaseHelper;
 import com.benny.openlauncher.util.Definitions;
@@ -44,7 +45,7 @@ public class SettingsMiscellaneousFragment extends SettingsBaseFragment {
                 return true;
             case R.string.pref_key__restore:
                 if (new PermissionChecker(getActivity()).doIfExtStoragePermissionGranted()) {
-                    Intent i = new Intent(getActivity(), FilePickerActivity.class)
+                    Intent i = new Intent(getActivity(), ZipFilePickerActivity.class)
                             .putExtra(FilePickerActivity.EXTRA_ALLOW_CREATE_DIR, false)
                             .putExtra(FilePickerActivity.EXTRA_MODE, FilePickerActivity.MODE_FILE);
                     getActivity().startActivityForResult(i, Definitions.INTENT_RESTORE);

--- a/app/src/main/java/com/benny/openlauncher/fragment/ZipFilePickerFragment.java
+++ b/app/src/main/java/com/benny/openlauncher/fragment/ZipFilePickerFragment.java
@@ -1,0 +1,38 @@
+package com.benny.openlauncher.fragment;
+
+import android.support.annotation.NonNull;
+
+import com.nononsenseapps.filepicker.FilePickerFragment;
+
+import java.io.File;
+
+public class ZipFilePickerFragment extends FilePickerFragment {
+    // File extension to filter on, including the initial dot.
+    private static final String EXTENSION = ".zip";
+
+    /**
+     * @param file
+     * @return The file extension. If file has no extension, it returns null.
+     */
+    private String getExtension(@NonNull File file) {
+        String path = file.getPath();
+        int i = path.lastIndexOf(".");
+        if (i < 0) {
+            return null;
+        } else {
+            return path.substring(i);
+        }
+    }
+
+    @Override
+    protected boolean isItemVisible(final File file) {
+        // simplified behavior   (see below full code)
+        // return isDir(file) || (mode == MODE_FILE || mode == MODE_FILE_AND_DIR);
+        if (!isDir(file) && (mode == MODE_FILE || mode == MODE_FILE_AND_DIR)) {
+            String ext = getExtension(file);
+            return ext != null && EXTENSION.equalsIgnoreCase(ext);
+        }
+        return isDir(file);
+    }
+
+}


### PR DESCRIPTION
Fixes #685.

Please review the code carefully. It works locally on my Fairphone 4 5G, but I'm not a Java developer, nor Android developer.

PR is based on code from https://stackoverflow.com/questions/31285273/how-do-i-use-a-filteredfilepickerfragment-for-nononsense-filepicker and code from http://spacecowboy.github.io/NoNonsense-FilePicker/example/filter_file_extension/

Please refer to your legal team to make sure using the code from stackoverflow this way is compatible with OpenLaunchers license.