### PR TITLE
locked: Don't show "uninstall" and "info", esp. not for shortcuts

### DIFF
--- a/app/src/main/java/com/benny/openlauncher/widget/ItemOptionView.java
+++ b/app/src/main/java/com/benny/openlauncher/widget/ItemOptionView.java
@@ -438,9 +438,6 @@ public final class ItemOptionView extends FrameLayout {
                         itemList.add(getAppShortcutItem(shortcutInfo));
                     }
                 }
-            case SHORTCUT:
-                itemList.add(uninstallItem);
-                itemList.add(infoItem);
                 break;
         }
 


### PR DESCRIPTION
Closes: https://github.com/OpenLauncherTeam/openlauncher/issues/698

---

This seems to have been a mixture of accidental implicit fall-through, and copy-pasted code in a little-used branch, and cases (unlocked and locked) getting out of sync. Removing not only "Uninstall" but also "Info" keeps consistency with the 0.7.4 behavior, and keeps the "locked" behavior of providing little avenue for clumsy users to get into areas they don't want to go.

<del>*Status:* This is a draft PR while I have not tested an of this. (I don't really do Android development, have no SDK for reformatting around, and rely on CI to do all the building for me, as little as I like depending on it).</del> Tested and works.